### PR TITLE
[FIX] Show filters related to timeboxes on the search view + Fix encoding issue

### DIFF
--- a/project_gtd/project_gtd.py
+++ b/project_gtd/project_gtd.py
@@ -152,7 +152,7 @@ class project_task(osv.Model):
                 cr, uid, timebox_obj.search(cr, uid, []), context=context)
             search_extended = ''
             for timebox in timeboxes:
-                filter_ = """
+                filter_ = u"""
                     <filter domain="[('timebox_id', '=', {timebox_id})]"
                             string="{string}"/>\n
                     """.format(timebox_id=timebox.id, string=timebox.name)

--- a/project_gtd/project_gtd_view.xml
+++ b/project_gtd/project_gtd_view.xml
@@ -98,6 +98,11 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.view_task_search_form"/>
         <field name="arch" type="xml">
+            <filter name="message_unread" position="after">
+                <group string="Timebox">
+                    <separator name="gtdsep"/>
+                </group>
+            </filter>
             <filter string="Last Message" position="after">
                 <filter name="timebox_id" string="Timebox" domain="[]" context="{'group_by': 'timebox_id'}"/>
                 <filter name="context_id" string="Context" domain="[]" context="{'group_by': 'context_id'}"/>


### PR DESCRIPTION
This fix show the 'timebox' filters on the search view like before (dynamically added on the 'fields_view_get()'), and fix an encoding issue if the name of the timebox has non-ascii characters.
