### PR TITLE
Fix error on Project Manager rule

### DIFF
--- a/project_baseuser/security/project_security.xml
+++ b/project_baseuser/security/project_security.xml
@@ -9,16 +9,12 @@
         <!-- Project Managers (modified): no longer see all projects: will have same visibility rules as Project Users -->
         <record model="ir.rule" id="project.project_project_manager_rule">
             <field name="name">Project: project manager: does not see all (modified)</field>
-            <field name="domain_force">[(1, '=', 0)]</field>
+            <field name="domain_force">[('id', '=', 0)]</field>
             <!-- Original data:
             <field name="model_id" ref="model_project_project"/>
             <field name="domain_force">[(1, '=', 1)]</field>
-            <field name="groups" eval="[(4,ref('project.group_project_manager'))]"/>
+            <field name="groups" eval="[(6,0,[ref('base.group_no_one')])]"/>
             -->
-            <field name="perm_read" eval="True"/>
-            <field name="perm_create" eval="False"/>
-            <field name="perm_write" eval="False"/>
-            <field name="perm_unlink" eval="False"/>
         </record>
 
 


### PR DESCRIPTION
Condition (1,'=',0) errors. Workaround is to make the former "access to all" rule only
to the Technical Features group.
