### PR TITLE
Restore the State field to Project Task

### DIFF
--- a/project_stage_state/project.py
+++ b/project_stage_state/project.py
@@ -32,3 +32,8 @@ _TASK_STATE = [
 class ProjectTaskType(models.Model):
     _inherit = 'project.task.type'
     state = fields.Selection(_TASK_STATE, 'State')
+
+
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+    state = fields.Selection(related='stage_id.state', store=True)


### PR DESCRIPTION
For the cases where some 7.0 processes still rely on the `state` field.
