### PR TITLE
Project SLA: refactoring and improvement, to make it more generic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,10 @@ virtualenv:
   system_site_packages: true
 
 env:
-  - VERSION="7.0" ODOO_REPO="odoo/odoo"
-  - VERSION="7.0" ODOO_REPO="OCA/OCB"
-  - VERSION="7.0" ODOO_REPO="odoo/odoo" UNIT_TEST="1"
+   - VERSION="7.0" LINT_CHECK="1"
+   - VERSION="7.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
+   - VERSION="7.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
+   - VERSION="7.0" UNIT_TEST="1" LINT_CHECK="0" 
 
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git $HOME/maintainer-quality-tools

--- a/project_sla/analytic_account.py
+++ b/project_sla/analytic_account.py
@@ -38,8 +38,7 @@ class AnalyticAccount(orm.Model):
         The ``recalc_closed`` flag allows to also recompute closed documents.
         """
         ctrl_obj = self.pool.get('project.sla.control')
-        proj_obj = self.pool.get('project.project')
-        exclude_states = ['cancelled'] + (not recalc_closed and ['done'] or [])
+        exclude_states = ['cancelled', 'cancel'] + (not recalc_closed and ['done'] or [])
         for contract in self.browse(cr, uid, ids, context=context):
             # for each contract, and for each model under SLA control ...
             for m_name in set([sla.control_model for sla in contract.sla_ids]):
@@ -52,12 +51,9 @@ class AnalyticAccount(orm.Model):
                          ('state', 'not in', exclude_states)],
                         context=context)
                 if 'project_id' in model._columns:
-                    proj_ids = proj_obj.search(
-                        cr, uid, [('analytic_account_id', '=', contract.id)],
-                        context=context)
                     doc_ids += model.search(
                         cr, uid,
-                        [('project_id', 'in', proj_ids),
+                        [('project_id.analytic_account_id', '=', contract.id),
                          ('state', 'not in', exclude_states)],
                         context=context)
                 if doc_ids:

--- a/project_sla/analytic_account.py
+++ b/project_sla/analytic_account.py
@@ -38,7 +38,11 @@ class AnalyticAccount(orm.Model):
         The ``recalc_closed`` flag allows to also recompute closed documents.
         """
         ctrl_obj = self.pool.get('project.sla.control')
-        exclude_states = ['cancelled', 'cancel'] + (not recalc_closed and ['done'] or [])
+
+        exclude_states = ['cancelled', 'cancel']
+        if not recalc_closed:
+            exclude_states += ['done']
+
         for contract in self.browse(cr, uid, ids, context=context):
             # for each contract, and for each model under SLA control ...
             for m_name in set([sla.control_model for sla in contract.sla_ids]):

--- a/project_sla/project_sla_control.py
+++ b/project_sla/project_sla_control.py
@@ -144,8 +144,10 @@ class SLAControl(orm.Model):
         end date will be 19:00 of the next day, and it should rather be
         16:00 of the next day.
         """
-        assert isinstance(start_date, dt), "start_date must be instance of 'datetime'. Got %s" % repr(start_date)
-        assert isinstance(hours, int) and hours >= 0, "hours must be int and >= 0. got %s" % repr(hours)
+        assert isinstance(start_date, dt), (
+            "start_date must be instance of 'datetime'.")
+        assert isinstance(hours, int) and hours >= 0, (
+            "hours must be int and >= 0. got %s" % repr(hours))
 
         cal_obj = self.pool.get('resource.calendar')
         target, step = hours * 3600, 16 * 3600
@@ -187,7 +189,8 @@ class SLAControl(orm.Model):
         def get_sla_date(sla, doc, field='control'):
             """ Converts control field value to datetime object.
             """
-            assert field in ('control', 'start'), "field must be in ('control', 'start')"
+            assert field in ('control', 'start'), (
+                "field must be in ('control', 'start')")
             if field == 'control':
                 sla_field = sla.control_field_id
             elif field == 'start':
@@ -330,10 +333,13 @@ class SLAControlled(orm.AbstractModel):
     def write(self, cr, uid, ids, vals, context=None):
         res = super(SLAControlled, self).write(
             cr, uid, ids, vals, context=context)
-        doc_ids = self.search(cr, uid, [('id','in',ids),
-                                        ('state', 'not in', ('cancelled', 'cancel')),
-                                        '|', ('state', '!=', 'done'),
-                                             ('sla_state', 'not in', ('1', '5'))], context=context)
+        doc_domain = [
+            ('id', 'in', ids),
+            ('state', 'not in', ('cancelled', 'cancel')),
+            '|', ('state', '!=', 'done'),
+                 ('sla_state', 'not in', ('1', '5'))
+        ]
+        doc_ids = self.search(cr, uid, doc_domain, context=context)
         self.store_sla_control(cr, uid, doc_ids, context=context)
         return res
 

--- a/project_sla/project_sla_control.py
+++ b/project_sla/project_sla_control.py
@@ -266,7 +266,7 @@ class SLAControl(orm.Model):
         ``docs`` is a Browse object
         """
         # context flag to avoid infinite loops on further writes
-        context = context or {}
+        context = {} if context is None else context.copy()
         if '__sla_stored__' in context:
             return False
         else:

--- a/project_sla/project_sla_demo.xml
+++ b/project_sla/project_sla_demo.xml
@@ -88,6 +88,8 @@
             <field name="control_model">project.issue</field>
             <field name="control_field_id"
                    ref="project_issue.field_project_issue_date_closed"/>
+            <field name="start_field_id"
+                   ref="project_issue.field_project_issue_create_date"/>
         </record>
             <record id="sla_resolution_rule1" model="project.sla.line">
                 <field name="sla_id" ref="sla_resolution"/>
@@ -111,6 +113,8 @@
             <field name="control_model">project.issue</field>
             <field name="control_field_id"
                    ref="project_issue.field_project_issue_date_open"/>
+            <field name="start_field_id"
+                   ref="project_issue.field_project_issue_create_date"/>
         </record>
             <record id="sla_response_rule1" model="project.sla.line">
                 <field name="sla_id" ref="sla_response"/>

--- a/project_sla/project_sla_view.xml
+++ b/project_sla/project_sla_view.xml
@@ -11,8 +11,41 @@
                     <field name="sequence"/>
                     <field name="name"/>
                     <field name="condition"/>
-                    <field name="limit_qty"/>
                     <field name="warn_qty"/>
+                    <field name="limit_qty"/>
+                </tree>
+
+            </field>
+        </record>
+
+        <record id="view_sla_lines_form" model="ir.ui.view">
+            <field name="name">view_sla_lines_form</field>
+            <field name="model">project.sla.line</field>
+            <field name="arch" type="xml">
+
+                <form string="Definition">
+                    <field name="name"/>
+                    <field name="sla_id"/>
+                    <field name="sequence"/>
+                    <field name="condition"/>
+                    <field name="warn_qty"/>
+                    <field name="limit_qty"/>
+                </form>
+
+            </field>
+        </record>
+
+        <record id="view_sla_tree" model="ir.ui.view">
+            <field name="name">view_sla_tree</field>
+            <field name="model">project.sla</field>
+            <field name="arch" type="xml">
+
+                <tree string="SLA Definitions">
+                  <field name="name"/>
+                  <field name="control_model"/>
+                  <field name="start_field_id"/>
+                  <field name="control_field_id"/>
+                  <field name="active"/>
                 </tree>
 
             </field>
@@ -24,10 +57,18 @@
             <field name="arch" type="xml">
 
                 <form string="SLA Definition">
-                  <field name="name"/>
-                  <field name="active"/>
-                  <field name="control_model"/>
-                  <field name="control_field_id"/>
+                  <group>
+                    <group>
+                        <field name="name"/>
+                        <field name="active"/>
+                    </group>
+                    <group>
+                        <field name="control_model"/>
+                        <field name="start_field_id"/>
+                        <field name="control_field_id"/>
+                    </group>
+                  </group>
+
                   <notebook colspan="4">
                     <page string="Rules" name="rules_page">
                       <field name="sla_line_ids" nolabel="1"/>

--- a/project_sla/project_sla_view.xml
+++ b/project_sla/project_sla_view.xml
@@ -85,5 +85,12 @@
             </field>
         </record>
 
+        <record id="action_project_sla_view" model="ir.actions.act_window">
+            <field name="name">SLA</field>
+            <field name="res_model">project.sla</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+        <menuitem id="menu_project_sla" name="SLAs" action="action_project_sla_view"
+                  parent="base.menu_definitions" sequence="100"/>
     </data>
 </openerp>


### PR DESCRIPTION
What is done:
1. Added 'start_field_id' field to 'project.sla' model same as
   'control_field_id' field. This will make simpler integration with
   objects that have no 'create_date' field, or such field have other
   name. Also this will allow to control not only time from
   confirmation, but any cobination of date fields of object (model)
2. Added sql constraints to check if 'limit_qty' and 'warn_qty' entered
   correctly.
3. Partly fixed bug when control field is of type 'date' not 'datetime'
   Partly, because of, may be, incorect calculation of time when not
   exact time specified. but now it will not throw error.
   May be start using UoMs here, to be able calculate time diferences
   in hours or days, what can be choosed by user?
4. Bugfix with user_id. Now there no errors will be thrown on attempt
   to create SLA for model, which has no 'user_id' field
5. Changed code, that checks for `doc.state != 'cancelled'` to
   `doc.state not in ('cancelled', 'cancel')` because of
   'cancelled' state is not standard in other apps, in most apps
   'cancel' state used instead
6. Views refactoring. Especialy tree view added for 'project.sla'
   model, which shows model name and control field names in tree.
