### PR TITLE
Add analytic account id on hours block

### DIFF
--- a/analytic_hours_block/__init__.py
+++ b/analytic_hours_block/__init__.py
@@ -22,3 +22,4 @@ from . import hours_block
 from . import report
 from . import product
 from . import project
+from . import account_analytic

--- a/analytic_hours_block/account_analytic.py
+++ b/analytic_hours_block/account_analytic.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from osv import orm
-from openerp.tools.translate import _
 
 
 class account_analytic(orm.Model):
@@ -10,17 +9,24 @@ class account_analytic(orm.Model):
                     operator='ilike', context=None, limit=80):
         if context is None:
             context = {}
-        if not context.has_key('hours_block_search_invoice_id'):
-            return super(account_analytic, self).name_search(cr, uid, name, args,
-                    operator, context,limit )
+        if 'hours_block_search_invoice_id' not in context:
+            return super(account_analytic, self).name_search(cr, uid,
+                                                             name, args,
+                                                             operator,
+                                                             context, limit)
         else:
             invoice_id = context['hours_block_search_invoice_id']
             invoice_line_obj = self.pool['account.invoice.line']
             invoice_lines_ids = invoice_line_obj.search(cr, uid,
-                                                        [('invoice_id','=',invoice_id)], context=context)
+                                                        [('invoice_id',
+                                                          '=',
+                                                          invoice_id)],
+                                                        context=context)
             account = []
-            for line in invoice_line_obj.browse(cr, uid, invoice_lines_ids, context=context):
+            for line in invoice_line_obj.browse(cr, uid,
+                                                invoice_lines_ids,
+                                                context=context):
                 if line.account_analytic_id:
                     account.append(line.account_analytic_id.id)
-            
+
             return self.name_get(cr, uid, account, context=context)

--- a/analytic_hours_block/account_analytic.py
+++ b/analytic_hours_block/account_analytic.py
@@ -28,11 +28,7 @@ class account_analytic(orm.Model):
                     operator='ilike', context=None, limit=80):
         if context is None:
             context = {}
-        if 'hours_block_search_invoice_id' not in context:
-            return super(account_analytic, self).name_search(
-                cr=cr, uid=uid, name=name, args=args, operator=operator,
-                context=context, limit=limit)
-        else:
+        if 'hours_block_search_invoice_id' in context:
             invoice_id = context['hours_block_search_invoice_id']
             invoice_line_obj = self.pool['account.invoice.line']
             invoice_lines_ids = invoice_line_obj.search(
@@ -45,3 +41,7 @@ class account_analytic(orm.Model):
                     account.append(line.account_analytic_id.id)
 
             return self.name_get(cr, uid, account, context=context)
+        else:
+            return super(account_analytic, self).name_search(
+                cr=cr, uid=uid, name=name, args=args, operator=operator,
+                context=context, limit=limit)

--- a/analytic_hours_block/account_analytic.py
+++ b/analytic_hours_block/account_analytic.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from osv import orm
+from openerp.tools.translate import _
+
+
+class account_analytic(orm.Model):
+    _inherit = 'account.analytic.account'
+
+    def name_search(self, cr, uid, name, args=None,
+                    operator='ilike', context=None, limit=80):
+        if context is None:
+            context = {}
+        if not context.has_key('hours_block_search_invoice_id'):
+            return super(project_project, self).name_search(self, cr, uid, name, args,
+                    operator, context, )
+        else:
+            invoice_id = context['hours_block_search_invoice_id']
+            invoice_line_obj = self.pool['account.invoice.line']
+            invoice_lines_ids = invoice_line_obj.search(cr, uid,
+                                                        [('invoice_id','=',invoice_id)], context=context)
+            account = []
+            for line in invoice_line_obj.browse(cr, uid, invoice_lines_ids, context=context):
+                if line.account_analytic_id:
+                    account.append(line.account_analytic_id.id)
+            
+            return self.name_get(cr, uid, account, context=context)

--- a/analytic_hours_block/account_analytic.py
+++ b/analytic_hours_block/account_analytic.py
@@ -17,11 +17,8 @@ class account_analytic(orm.Model):
         else:
             invoice_id = context['hours_block_search_invoice_id']
             invoice_line_obj = self.pool['account.invoice.line']
-            invoice_lines_ids = invoice_line_obj.search(cr, uid,
-                                                        [('invoice_id',
-                                                          '=',
-                                                          invoice_id)],
-                                                        context=context)
+            invoice_lines_ids = invoice_line_obj.search(
+                cr, uid, [('invoice_id', '=', invoice_id)], context=context)
             account = []
             for line in invoice_line_obj.browse(cr, uid,
                                                 invoice_lines_ids,

--- a/analytic_hours_block/account_analytic.py
+++ b/analytic_hours_block/account_analytic.py
@@ -1,5 +1,24 @@
 # -*- coding: utf-8 -*-
-from osv import orm
+##############################################################################
+#
+#    Author: Vincent Renaville, ported by Joel Grand-Guillaume
+#    Copyright 2010-2012 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.osv import orm
 
 
 class account_analytic(orm.Model):
@@ -10,10 +29,9 @@ class account_analytic(orm.Model):
         if context is None:
             context = {}
         if 'hours_block_search_invoice_id' not in context:
-            return super(account_analytic, self).name_search(cr, uid,
-                                                             name, args,
-                                                             operator,
-                                                             context, limit)
+            return super(account_analytic, self).name_search(
+                cr=cr, uid=uid, name=name, args=args, operator=operator,
+                context=context, limit=limit)
         else:
             invoice_id = context['hours_block_search_invoice_id']
             invoice_line_obj = self.pool['account.invoice.line']

--- a/analytic_hours_block/account_analytic.py
+++ b/analytic_hours_block/account_analytic.py
@@ -11,8 +11,8 @@ class account_analytic(orm.Model):
         if context is None:
             context = {}
         if not context.has_key('hours_block_search_invoice_id'):
-            return super(project_project, self).name_search(self, cr, uid, name, args,
-                    operator, context, )
+            return super(account_analytic, self).name_search(cr, uid, name, args,
+                    operator, context,limit )
         else:
             invoice_id = context['hours_block_search_invoice_id']
             invoice_line_obj = self.pool['account.invoice.line']

--- a/analytic_hours_block/hours_block.py
+++ b/analytic_hours_block/hours_block.py
@@ -167,6 +167,18 @@ class AccountHoursBlock(orm.Model):
                 [inv.id for inv in invoice.account_hours_block_ids])
         return list(block_ids)
 
+    def _get_analytic_account(self, cr, uid, ids, field_name, arg,
+                              context=None):
+        result = {}
+        for block in self.browse(cr, uid, ids, context=context):
+            if block.invoice_id:
+                account_ids = [x.account_analytic_id.id for x in block.invoice_id.invoice_line]
+                result[block.id] = account_ids
+            else:
+                result[block.id] = []
+        return result
+
+
     def action_send_block(self, cr, uid, ids, context=None):
         """Open a form to send by email. Return an action dict."""
 
@@ -257,6 +269,11 @@ class AccountHoursBlock(orm.Model):
             'Invoice',
             ondelete='cascade',
             required=True),
+        'account_analytic_id':fields.many2one(
+            'account.analytic.account',
+            'Account analytic',
+            required=True), 
+
         'type': fields.selection(
             [('hours', 'Hours'),
              ('amount', 'Amount')],

--- a/analytic_hours_block/hours_block.py
+++ b/analytic_hours_block/hours_block.py
@@ -31,8 +31,9 @@ class AccountHoursBlock(orm.Model):
         res = {}
         for block in self.browse(cr, uid, ids, context=context):
             cr.execute("SELECT max(al.date) FROM account_analytic_line AS al"
-                       " WHERE al.invoice_id = %s and al.account_id = %s", (block.invoice_id.id,
-                                                                            block.account_analytic_id.id))
+                       " WHERE al.invoice_id = %s "
+                       " and al.account_id = %s",
+                       (block.invoice_id.id, block.account_analytic_id.id))
             fetch_res = cr.fetchone()
             res[block.id] = fetch_res[0] if fetch_res else False
         return res
@@ -68,7 +69,8 @@ class AccountHoursBlock(orm.Model):
                        "WHERE aj.id = al.journal_id "
                        "AND aj.type = 'general' "
                        "  AND al.invoice_id = %s"
-                       "  AND al.account_id = %s", (block.invoice_id.id,block.account_analytic_id.id))
+                       "  AND al.account_id = %s",
+                       (block.invoice_id.id, block.account_analytic_id.id))
             res_line_ids = cr.fetchall()
             line_ids = [l[0] for l in res_line_ids] if res_line_ids else []
             for line in aal_obj.browse(cr, uid, line_ids, context=context):
@@ -105,14 +107,15 @@ class AccountHoursBlock(orm.Model):
                 result[block.id]['amount_hours_block'] += amount_bought
 
             # Compute total amount
-            # Get ids of analytic line generated from timesheet associated to
-            # current block
+            # Get ids of analytic line generated from timesheet
+            # associated to current block
             cr.execute("SELECT al.id FROM account_analytic_line AS al,"
                        " account_analytic_journal AS aj"
                        " WHERE aj.id = al.journal_id"
                        "  AND aj.type='general'"
                        "  AND al.invoice_id = %s"
-                       "  AND al.account_id = %s", (block.invoice_id.id,block.account_analytic_id.id))
+                       "  AND al.account_id = %s",
+                       (block.invoice_id.id, block.account_analytic_id.id))
             res_line_ids = cr.fetchall()
             line_ids = [l[0] for l in res_line_ids] if res_line_ids else []
             total_amount = 0.0
@@ -143,8 +146,8 @@ class AccountHoursBlock(orm.Model):
         for block_type in block_per_types:
             if block_type:
                 func = getattr(self, "_compute_%s" % block_type)
-                result.update(
-                    func(cr, uid, ids, fields, args, context=context))
+                result.update(func(cr, uid, ids,
+                                   fields, args, context=context))
 
         for block in result:
             result[block]['amount_hours_block_delta'] = \
@@ -166,10 +169,9 @@ class AccountHoursBlock(orm.Model):
         block_ids = set()
         inv_obj = self.pool.get('account.invoice')
         for invoice in inv_obj.browse(cr, uid, ids, context=context):
-            block_ids.update(
-                [inv.id for inv in invoice.account_hours_block_ids])
+            block_ids.update([inv.id for inv
+                              in invoice.account_hours_block_ids])
         return list(block_ids)
-
 
     def action_send_block(self, cr, uid, ids, context=None):
         """Open a form to send by email. Return an action dict."""
@@ -261,10 +263,10 @@ class AccountHoursBlock(orm.Model):
             'Invoice',
             ondelete='cascade',
             required=True),
-        'account_analytic_id':fields.many2one(
+        'account_analytic_id': fields.many2one(
             'account.analytic.account',
             'Account analytic',
-            required=True), 
+            required=True),
 
         'type': fields.selection(
             [('hours', 'Hours'),

--- a/analytic_hours_block/hours_block.py
+++ b/analytic_hours_block/hours_block.py
@@ -32,7 +32,7 @@ class AccountHoursBlock(orm.Model):
         for block in self.browse(cr, uid, ids, context=context):
             cr.execute("SELECT max(al.date) FROM account_analytic_line AS al"
                        " WHERE al.invoice_id = %s "
-                       " and al.account_id = %s",
+                       " AND al.account_id = %s",
                        (block.invoice_id.id, block.account_analytic_id.id))
             fetch_res = cr.fetchone()
             res[block.id] = fetch_res[0] if fetch_res else False

--- a/analytic_hours_block/hours_block.py
+++ b/analytic_hours_block/hours_block.py
@@ -31,7 +31,8 @@ class AccountHoursBlock(orm.Model):
         res = {}
         for block in self.browse(cr, uid, ids, context=context):
             cr.execute("SELECT max(al.date) FROM account_analytic_line AS al"
-                       " WHERE al.invoice_id = %s", (block.invoice_id.id,))
+                       " WHERE al.invoice_id = %s and al.account_id = %s", (block.invoice_id.id,
+                                                                            block.account_analytic_id.id))
             fetch_res = cr.fetchone()
             res[block.id] = fetch_res[0] if fetch_res else False
         return res
@@ -66,7 +67,8 @@ class AccountHoursBlock(orm.Model):
                        "     account_analytic_journal AS aj "
                        "WHERE aj.id = al.journal_id "
                        "AND aj.type = 'general' "
-                       "AND al.invoice_id = %s", (block.invoice_id.id,))
+                       "  AND al.invoice_id = %s"
+                       "  AND al.account_id = %s", (block.invoice_id.id,block.account_analytic_id.id))
             res_line_ids = cr.fetchall()
             line_ids = [l[0] for l in res_line_ids] if res_line_ids else []
             for line in aal_obj.browse(cr, uid, line_ids, context=context):
@@ -109,7 +111,8 @@ class AccountHoursBlock(orm.Model):
                        " account_analytic_journal AS aj"
                        " WHERE aj.id = al.journal_id"
                        "  AND aj.type='general'"
-                       "  AND al.invoice_id = %s", (block.invoice_id.id,))
+                       "  AND al.invoice_id = %s"
+                       "  AND al.account_id = %s", (block.invoice_id.id,block.account_analytic_id.id))
             res_line_ids = cr.fetchall()
             line_ids = [l[0] for l in res_line_ids] if res_line_ids else []
             total_amount = 0.0
@@ -166,17 +169,6 @@ class AccountHoursBlock(orm.Model):
             block_ids.update(
                 [inv.id for inv in invoice.account_hours_block_ids])
         return list(block_ids)
-
-    def _get_analytic_account(self, cr, uid, ids, field_name, arg,
-                              context=None):
-        result = {}
-        for block in self.browse(cr, uid, ids, context=context):
-            if block.invoice_id:
-                account_ids = [x.account_analytic_id.id for x in block.invoice_id.invoice_line]
-                result[block.id] = account_ids
-            else:
-                result[block.id] = []
-        return result
 
 
     def action_send_block(self, cr, uid, ids, context=None):

--- a/analytic_hours_block/hours_block_view.xml
+++ b/analytic_hours_block/hours_block_view.xml
@@ -55,6 +55,7 @@
                         </h1>
 
                         <group>
+                            <field name="account_analytic_id" context="{'hours_block_search_invoice_id':invoice_id}"/>
                             <field name="last_action_date" />
                             <field name="close_date" />
                         </group>

--- a/analytic_hours_block/project.py
+++ b/analytic_hours_block/project.py
@@ -14,11 +14,12 @@ class project_project(orm.Model):
             cr, uid,
             [('account_analytic_id',
               '=',
-              project.analytic_account_id.id)])
+              project.analytic_account_id.id)], context=context)
         invoice_lines = invoice_line_obj.browse(cr, uid, invoice_line_ids)
         invoice_ids = [x.invoice_id.id for x in invoice_lines]
         res_ids = hours_block_obj.search(cr, uid, [('invoice_id',
-                                                    'in', invoice_ids)])
+                                                    'in', invoice_ids)],
+                                         context=context)
         domain = False
         if res_ids:
             domain = [('id', 'in', res_ids)]

--- a/analytic_hours_block/project.py
+++ b/analytic_hours_block/project.py
@@ -11,17 +11,20 @@ class project_project(orm.Model):
         hours_block_obj = self.pool.get('account.hours.block')
         project = self.browse(cr, uid, ids)[0]
         invoice_line_ids = invoice_line_obj.search(
-            cr, uid, [('account_analytic_id', '=', project.analytic_account_id.id)])
+            cr, uid,
+            [('account_analytic_id',
+              '=',
+              project.analytic_account_id.id)])
         invoice_lines = invoice_line_obj.browse(cr, uid, invoice_line_ids)
         invoice_ids = [x.invoice_id.id for x in invoice_lines]
-        res_ids = hours_block_obj.search(
-            cr, uid, [('invoice_id', 'in', invoice_ids)])
+        res_ids = hours_block_obj.search(cr, uid, [('invoice_id',
+                                                    'in', invoice_ids)])
         domain = False
         if res_ids:
             domain = [('id', 'in', res_ids)]
         else:
-            raise orm.except_orm(
-                _('Warning'), _("No Hours Block for this project"))
+            raise orm.except_orm(_('Warning'),
+                                 _("No Hours Block for this project"))
 
         return {
             'name': _('Hours Blocks'),

--- a/analytic_hours_block/report/hours_block.py
+++ b/analytic_hours_block/report/hours_block.py
@@ -20,9 +20,10 @@
 ##############################################################################
 
 import time
+from openerp.osv import osv
 from openerp.report import report_sxw
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
-
+from openerp.tools.translate import _
 
 class account_hours_block(report_sxw.rml_parse):
 
@@ -36,15 +37,19 @@ class account_hours_block(report_sxw.rml_parse):
         self.context = context
 
     def _get_analytic_lines(self, hours_block):
+        hours_pool = self.pool['account.hours.block']
         al_pool = self.pool.get('account.analytic.line')
         aj_pool = self.pool.get('account.analytic.journal')
         tcj_ids = aj_pool.search(self.cr, self.uid,
                                  [('type', '=', 'general')])
+        domain = [('invoice_id', '=', hours_block.invoice_id.id),
+                  ('journal_id', 'in', tcj_ids),
+                 ]
+        if hours_block.account_analytic_id:
+            domain.append(('account_id','=',hours_block.account_analytic_id.id))
         al_ids = al_pool.search(self.cr,
                                 self.uid,
-                                [('invoice_id', '=', hours_block.invoice_id.id),
-                                 ('journal_id', 'in', tcj_ids),
-                                 ],
+                                domain,
                                 order='date desc',
                                 context=self.context)
         return al_pool.browse(self.cr, self.uid, al_ids, context=self.context)

--- a/analytic_hours_block/report/hours_block.py
+++ b/analytic_hours_block/report/hours_block.py
@@ -20,16 +20,14 @@
 ##############################################################################
 
 import time
-from openerp.osv import osv
 from openerp.report import report_sxw
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
-from openerp.tools.translate import _
+
 
 class account_hours_block(report_sxw.rml_parse):
-
     def __init__(self, cr, uid, name, context=None):
-        super(account_hours_block, self).__init__(
-            cr, uid, name, context=context)
+        super(account_hours_block, self).__init__(cr, uid,
+                                                  name, context=context)
         self.localcontext.update({'time': time,
                                   'date_format': DEFAULT_SERVER_DATE_FORMAT,
                                   'analytic_lines': self._get_analytic_lines,
@@ -37,16 +35,15 @@ class account_hours_block(report_sxw.rml_parse):
         self.context = context
 
     def _get_analytic_lines(self, hours_block):
-        hours_pool = self.pool['account.hours.block']
         al_pool = self.pool.get('account.analytic.line')
         aj_pool = self.pool.get('account.analytic.journal')
         tcj_ids = aj_pool.search(self.cr, self.uid,
                                  [('type', '=', 'general')])
         domain = [('invoice_id', '=', hours_block.invoice_id.id),
-                  ('journal_id', 'in', tcj_ids),
-                 ]
+                  ('journal_id', 'in', tcj_ids), ]
         if hours_block.account_analytic_id:
-            domain.append(('account_id','=',hours_block.account_analytic_id.id))
+            domain.append(('account_id', '=',
+                           hours_block.account_analytic_id.id))
         al_ids = al_pool.search(self.cr,
                                 self.uid,
                                 domain,


### PR DESCRIPTION
In some case invoice have mutiple invoice line with different analytic account set on it.
This improvement allow to specified the analytic account that you want to manage with this hours block, so it deduced hours only if analytic lines linked is on the account specified in the hours block.
