### PR TITLE
Make current user the Issues default Contact person

### DIFF
--- a/service_desk_issue/project.py
+++ b/service_desk_issue/project.py
@@ -41,6 +41,12 @@ class ProjectIssue(orm.Model):
             'project_id', 'code', type='char', string="Project Code"),
         }
 
+    _defaults = {
+        # In self-service issues the default Contact is the current user
+        'partner_id': lambda s, cr, uid, c: s.pool['res.users'].browse(
+            cr, uid, uid, context=c).partner_id.id
+    }
+
     def onchange_project(self, cr, uid, id, project_id, context=None):
         # on_change is necessary to populate fields on Create, before saving
         try:


### PR DESCRIPTION
It is expected for users to open Issues, so the Contact information
should be the current user. The Responsible person is not an option,
since it will be changed to the assigned person in the support team.

This was already the behaviour in version 7.0, and was removed in
version 8.0.
