### PR TITLE
Make the 'Working Time' field always visible on Projects

### DIFF
--- a/project_sla/project_view.xml
+++ b/project_sla/project_view.xml
@@ -9,9 +9,9 @@
             <field name="arch" type="xml">
 
                 <!-- make resource calendar always visible -->
-                <group string="Administration" position="attributes">
+                <field name="resource_calendar_id" position="attributes">
                     <attribute name="groups"/>
-                </group>
+                </field>
 
            </field>
         </record>


### PR DESCRIPTION
Fixes #70

![snap 2015-04-10 at 10 39 25](https://cloud.githubusercontent.com/assets/1246629/7085426/8951067c-df6e-11e4-8395-a23768f2748f.png)
