### PR TITLE
Allow setting warnings on Tasks related to Contracts

### DIFF
--- a/analytic_warning/README.rst
+++ b/analytic_warning/README.rst
@@ -1,0 +1,35 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Contract Warning Messages for Project Tasks
+===========================================
+
+Display warnings when selecting a Contract on a Project Task.
+
+For example, this is useful to alert the user that a certain customer
+has no service contracted or some approval procedure should be initiated
+before requesting service.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Daniel Reis
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/analytic_warning/README.rst
+++ b/analytic_warning/README.rst
@@ -1,6 +1,8 @@
 .. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
-    :alt: License: AGPL-3
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
 
+===========================================
 Contract Warning Messages for Project Tasks
 ===========================================
 
@@ -11,13 +13,60 @@ has no service contracted or some approval procedure should be initiated
 before requesting service.
 
 
+Installation
+============
+
+No specifc actions needed.
+This module depends on the Service Desk.
+
+
+Configuration
+=============
+
+On the Partner form, edit the Task Warning Type and
+Task Warning Message.
+
+
+Usage
+=====
+
+Go to Project Tasks, and create a new Task.
+Choose a Contract for a Customer with a warning configured.
+A popup warning message will be shown.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/140/8.0
+
+.. repo_id is available in https://github.com/OCA/maintainer-tools/blob/master/tools/repos_with_ids.txt
+.. branch is "8.0" for example
+
+Known issues / Roadmap
+======================
+
+* ...
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/project/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
 Credits
 =======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
 
 Contributors
 ------------
 
 * Daniel Reis
+
 
 Maintainer
 ----------
@@ -32,4 +81,4 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-To contribute to this module, please visit http://odoo-community.org.
+To contribute to this module, please visit https://odoo-community.org.

--- a/analytic_warning/__init__.py
+++ b/analytic_warning/__init__.py
@@ -1,0 +1,2 @@
+from . import analytic_account_model
+from . import project_task_model

--- a/analytic_warning/__openerp__.py
+++ b/analytic_warning/__openerp__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': 'Contract Warning Messages for Project Tasks',
+    'summary': 'Display contract related  warning messages on Tasks',
+    'version': '1.0',
+    "category": "Project Management",
+    'author': "Daniel Reis, Odoo Community Association (OCA)",
+    'website': 'https://github.com/OCA/project-service',
+    'license': 'AGPL-3',
+    'depends': ['service_desk'],
+    'data': [
+        'analytic_account_view.xml',
+    ],
+    'installable': True,
+}

--- a/analytic_warning/__openerp__.py
+++ b/analytic_warning/__openerp__.py
@@ -18,7 +18,7 @@
 {
     'name': 'Contract Warning Messages for Project Tasks',
     'summary': 'Display contract related  warning messages on Tasks',
-    'version': '1.0',
+    'version': '8.0.1.0.0',
     "category": "Project Management",
     'author': "Daniel Reis, Odoo Community Association (OCA)",
     'website': 'https://github.com/OCA/project-service',

--- a/analytic_warning/analytic_account_model.py
+++ b/analytic_warning/analytic_account_model.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2013 Daniel Reis
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, fields
+from openerp.addons.warning.warning import (WARNING_MESSAGE, WARNING_HELP)
+
+
+class AnalyticAccount(models.Model):
+    _inherit = 'account.analytic.account'
+
+    project_task_warn = fields.Selection(
+        WARNING_MESSAGE, 'Task Warning Type',
+        help=WARNING_HELP, required=True, default='no-message')
+    project_task_warn_msg = fields.Text('Task Warning Message')

--- a/analytic_warning/analytic_account_model.py
+++ b/analytic_warning/analytic_account_model.py
@@ -1,22 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    Copyright (C) 2013 Daniel Reis
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Daniel Reis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, fields
 from openerp.addons.warning.warning import (WARNING_MESSAGE, WARNING_HELP)

--- a/analytic_warning/analytic_account_view.xml
+++ b/analytic_warning/analytic_account_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="view_analytic_account_add_warning" model="ir.ui.view">
+            <field name="name">Analytic Account: add Warning fields</field>
+            <field name="model">account.analytic.account</field>
+            <field name="inherit_id" ref="analytic.view_account_analytic_account_form" />
+            <field name="arch" type="xml">
+                <notebook position="inside">
+                    <page string="Warnings">
+                        <group string="Warning on Project Tasks">
+                            <field name="project_task_warn"/>
+                            <field name="project_task_warn_msg"
+                                attrs="{'required':[('project_task_warn', '!=', 'no-message')],
+                                        'readonly':[('project_task_warn', '=',  'no-message')]}"/>
+                        </group>
+                    </page>
+                </notebook>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/analytic_warning/project_task_model.py
+++ b/analytic_warning/project_task_model.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp import models, api, _
+
+
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+
+    @api.onchange('analytic_account_id')
+    def onchange_analytic(self):
+        res = super(ProjectTask, self).onchange_analytic()
+        warn = self.analytic_account_id.project_task_warn
+        if warn and warn != 'no-message':
+            warn_msg = {
+                'title': _("Warning: %s") % (self.name or ''),
+                'message': self.analytic_account_id.project_task_warn_msg}
+            if warn == 'block':
+                self.analytic_account_id = None
+                self.partner_id = None
+                self.location_id = None
+            res = {'warning': warn_msg}
+        return res

--- a/analytic_warning/project_task_model.py
+++ b/analytic_warning/project_task_model.py
@@ -1,20 +1,6 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2015 Daniel Reis
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import models, api, _
 

--- a/service_desk/service_desk_view.xml
+++ b/service_desk/service_desk_view.xml
@@ -44,7 +44,7 @@
 
                 <field name="project_id" position="before">
                             <field name="use_analytic_account" invisible="1"/>
-                            <field name="analytic_account_id" on_change="onchange_analytic(analytic_account_id)"
+                            <field name="analytic_account_id"
                                    attrs="{'invisible':[('use_analytic_account','not in',['yes','req'])],'required':[('use_analytic_account','=','req')]}"/>
                             <field name="location_id"
                                    attrs="{'invisible':[('use_analytic_account','not in',['yes','req'])],'required':[('use_analytic_account','=','req')]}"/>
@@ -52,6 +52,7 @@
 
                 <field name="project_id" position="attributes">
                     <attribute name="on_change">onchange_project(project_id)</attribute>
+                    w
                 </field>
 
            </field>


### PR DESCRIPTION
Depends on the Service Desk module, to allow relating a Project Task to a contract.
Adds warning configuration on Contracts / Analytic Accounts.
The warning messages will be presented to the user if that Contract is selected when editing a Task.

![snap 2015-05-13 at 14 20 43](https://cloud.githubusercontent.com/assets/1246629/7611335/bbf8cff2-f97b-11e4-8910-25707a7e2482.png)

It currently only works for the Analytic Account custom field, and not for the Project standard field. That might also make sense but it's not a use case I have now.
