### PR TITLE
New module "project_analytic_line_view"

### DIFF
--- a/project_analytic_line_view/README.rst
+++ b/project_analytic_line_view/README.rst
@@ -1,0 +1,46 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Analytic lines view from project
+================================
+
+
+Get Analytic Lines from project (with recursion in child account)
+
+Usage
+=====
+
+Use the new action available on the project.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/project-/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/project-reporting/issues/new?body=module:%20project_analytic_line_view%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Joël Grand-Guillaume <joel.grandguillaume@camptocamp.com>
+* Matthieu Dietrich <matthieu.dietrich@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/project_analytic_line_view/__init__.py
+++ b/project_analytic_line_view/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Joël Grand-Guillaume, Matthieu Dietrich
+#    Copyright 2010-2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import analytic_account

--- a/project_analytic_line_view/__openerp__.py
+++ b/project_analytic_line_view/__openerp__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Joël Grand-Guillaume, Matthieu Dietrich
+#    Copyright 2010-2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    'name': "Project analytic account line view",
+    'version': '1.0',
+    'category': 'Generic Modules/Projects & Services',
+    'author': "Camptocamp,Odoo Community Association (OCA)",
+    'website': 'http://www.camptocamp.com',
+    'license': 'AGPL-3',
+    'depends': ['project',
+                'analytic',
+                ],
+    'data': [
+        'analytic_account_view.xml',
+    ],
+    'test': [],
+    'installable': True,
+    'auto_install': False,
+    'application': False
+}

--- a/project_analytic_line_view/analytic_account.py
+++ b/project_analytic_line_view/analytic_account.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Author: Joël Grand-Guillaume, Matthieu Dietrich
+#    Copyright 2010-2015 Camptocamp SA
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp import models, fields
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = 'account.analytic.account'
+    _description = 'Analytic Account'
+
+    project_ids = fields.One2many('project.project', 'analytic_account_id',
+                                  string='Projects')

--- a/project_analytic_line_view/analytic_account_view.xml
+++ b/project_analytic_line_view/analytic_account_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<openerp>
+  <data>
+
+    <act_window
+      domain="[('account_id.project_ids', '=', active_id)]"
+      id="act_aal_from_project"
+      name="Analytic Lines"
+      res_model="account.analytic.line"
+      src_model="project.project"
+      view_mode="tree,form,calendar"
+      view_type="form"/>
+
+  </data>
+</openerp>


### PR DESCRIPTION
This PR is to create a new small module, `project_analytic_line_view`, which is in fact a part of the module `project_billing_utils` in https://github.com/OCA/project-reporting .

The main reason for this split is that the module `project_classification` (currently ported in PR https://github.com/OCA/project-service/pull/97 ) depends on this part of `project_billing_utils` ; however, adding a dependency in this functional module to a reporting module would be bad practice.

When this PR is validated, I will add the dependency to the new module in PR https://github.com/OCA/project-service/pull/97 , and remove the code + add the dependency in project-reporting.
