### PR TITLE
[ADD] module 'create_project_from_analytic'

### DIFF
--- a/create_project_from_analytic/README.rst
+++ b/create_project_from_analytic/README.rst
@@ -1,0 +1,69 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+====================================
+Create Project from Analytic Account
+====================================
+This module allows to create a Project from an existing Analytic Account.
+This creation is only possible for Analytic Accounts of type 'Contract or
+Project', that are not already assigned to an existing Project.
+
+
+Usage
+=====
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/140/8.0
+
+In the Analytic Accounts list view you can select the analytic accounts
+that you want, and then go to 'More' and 'Create Project'.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/project/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/project/issues/new?body=module:%20create_project_from_analytic%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+License
+=======
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/agpl-3.0-standalone.html>.
+
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/create_project_from_analytic/__init__.py
+++ b/create_project_from_analytic/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import wizards

--- a/create_project_from_analytic/__openerp__.py
+++ b/create_project_from_analytic/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Eficent - Jordi Ballester
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    'name': 'Create Project from Analytic Account',
+    'summary': 'Create a Project from an existing Analytic Account.',
+    'version': '8.0.1.0.0',
+    'category': "Project Management",
+    'author': 'Eficent, '
+              'Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
+    'depends': ['project'],
+    'data': [
+        'wizards/create_project_from_analytic_wizard_view.xml',
+    ],
+    'installable': True,
+    'auto_install': True,
+}

--- a/create_project_from_analytic/wizards/__init__.py
+++ b/create_project_from_analytic/wizards/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from . import create_project_from_analytic_wizard

--- a/create_project_from_analytic/wizards/create_project_from_analytic_wizard.py
+++ b/create_project_from_analytic/wizards/create_project_from_analytic_wizard.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# (c) 2015 Eficent - Jordi Ballester Alomar
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from openerp import models, fields, api, exceptions, _
+
+
+
+class CreateProjectFromAnalyticWizard(models.TransientModel):
+    """ Create a project from an existing analytic account."""
+    _name = 'create.project.from.analytic.wizard'
+    _description = __doc__
+
+    def _prepare_project_data(self, analytic):
+
+        return {
+            'analytic_account_id': analytic.id
+        }
+
+    @api.one
+    def confirm_create(self):
+        res = []
+        act_close = {'type': 'ir.actions.act_window_close'}
+        analytic_account_ids = self._context.get('active_ids')
+        if analytic_account_ids is None:
+            return act_close
+        analytic_model = self.env['account.analytic.account']
+        project_model = self.env['project.project']
+        for analytic in analytic_model.browse(analytic_account_ids):
+            if project_model.search([('analytic_account_id', '=',
+                                      analytic.id)]):
+                raise exceptions.Warning(
+                    _('Error!:: Analytic Account [%s] %s already has a '
+                      'project')
+                    % (analytic.code, analytic.name))
+            if analytic.type != 'contract':
+                raise exceptions.Warning(
+                    _('Error!:: Analytic Account [%s] %s is not of type '
+                      'Contract or Project')
+                    % (analytic.code, analytic.name))
+            project_data = self._prepare_project_data(analytic)
+            project = project_model.create(project_data)
+            res.append(project.id)
+
+        return {
+            'domain': "[('id','in', ["+','.join(map(str, res))+"])]",
+            'name': _('Project'),
+            'view_type': 'form',
+            'view_mode': 'tree,form',
+            'res_model': 'project.project',
+            'view_id': False,
+            'context': False,
+            'type': 'ir.actions.act_window'
+        }

--- a/create_project_from_analytic/wizards/create_project_from_analytic_wizard_view.xml
+++ b/create_project_from_analytic/wizards/create_project_from_analytic_wizard_view.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+        <!-- Start window -->
+
+        <record id="create_project_from_analytic_form" model="ir.ui.view">
+            <field name="name">create.project.from.analytic.form</field>
+            <field name="model">create.project.from.analytic.wizard</field>
+            <field name="arch" type="xml">
+                <form string="Create Project">
+                    <separator
+                        string="Create Project for selected Analytic Accounts?"
+                        colspan="4" />
+                    <footer>
+                        <button class="oe_highlight" name="confirm_create"
+                            string="Accept" type="object" />
+                        or
+                        <button class="oe_link" special="cancel"
+                            string="Cancel" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+
+        <!-- Action of create project from analytic wizard -->
+
+        <record id="action_create_project_from_analytic"
+                model="ir.actions.act_window">
+            <field name="name">Create Project</field>
+            <field name="res_model">create.project.from.analytic.wizard</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="view_id" ref="create_project_from_analytic_form" />
+            <field name="target">new</field>
+        </record>
+
+        <act_window name="Create Project From Analytic Account"
+                    res_model="create.project.from.analytic.wizard"
+            src_model="account.analytic.account" view_mode="form"
+                    target="new"
+            key2="client_action_multi" id="act_create_project_from_analytic" />
+
+  </data>
+</openerp>


### PR DESCRIPTION
This module allows to create a Project from an existing Analytic Account. This creation is only possible for Analytic Accounts of type 'Contract or Project', that are not already assigned to an existing Project.

In the Analytic Accounts list view you can select the analytic accounts that you want, and then go to 'More' and 'Create Project'.
