### PR TITLE
Project project recalculate

### DIFF
--- a/project_recalculate/models/project_project.py
+++ b/project_recalculate/models/project_project.py
@@ -64,10 +64,9 @@ class ProjectProject(models.Model):
                     project.date):
                 raise Warning(_("Cannot recalculate project because your "
                                 "project don't have date end."))
-            if project.calculation_type != 'none':
-                for task in project.tasks:
-                    task.task_recalculate()
-                vals = project._start_end_dates_prepare()
-                if vals:
-                    project.write(vals)
+            for task in project.tasks:
+                task.task_recalculate()
+            vals = project._start_end_dates_prepare()
+            if vals:
+                project.write(vals)
         return True


### PR DESCRIPTION
The field "calculation type" has 2 values: "date_begin", and "date_end", and it is initialized to False. In the "project recalculate" function asks for the following condition: "if project.calculation_type != 'none'", this condition is never given, because the field is initialized to False.
