### PR TITLE
[FIX] Add missing logic for yearly recurring invoices.

### DIFF
--- a/account_analytic_analysis_recurring/__openerp__.py
+++ b/account_analytic_analysis_recurring/__openerp__.py
@@ -1,28 +1,9 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenERP, Open Source Management Solution
-#    Copyright (C) 2004-2010 Tiny SPRL (<http://tiny.be>).
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
-
+# © 2004-2010 Tiny SPRL <http://tiny.be>.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     'name': 'Contracts Management recurring',
-    'version': '0.1',
+    'version': '7.0.0.1.1',
     'category': 'Other',
     'description': """
 This module adds a new feature in contracts to manage recurring invoicing
@@ -36,6 +17,7 @@ line description to automatically insert the dates of the invoiced period.
 
 Backport done By Yannick Buron.
 """,
+    "license": 'AGPL-3',
     'author': "OpenERP SA,Odoo Community Association (OCA)",
     'website': 'http://openerp.com',
     'depends': ['base', 'account_analytic_analysis'],
@@ -44,8 +26,5 @@ Backport done By Yannick Buron.
         'account_analytic_analysis_recurring_cron.xml',
         'account_analytic_analysis_recurring_view.xml',
     ],
-    'demo': [],
-    'test': [],
     'installable': True,
-    'images': [],
 }

--- a/account_analytic_analysis_recurring/account_analytic_analysis_recurring.py
+++ b/account_analytic_analysis_recurring/account_analytic_analysis_recurring.py
@@ -246,7 +246,7 @@ class AccountAnalyticAccount(orm.Model):
             elif contract.recurring_rule_type == 'monthly':
                 new_date = next_date + relativedelta(months=+interval)
             else:
-                new_date = next_date+relativedelta(years=+interval)
+                new_date = next_date + relativedelta(years=+interval)
             context['old_date'] = old_date
             context['next_date'] = new_date
             # Force company for correct evaluate domain access rules

--- a/account_analytic_analysis_recurring/account_analytic_analysis_recurring.py
+++ b/account_analytic_analysis_recurring/account_analytic_analysis_recurring.py
@@ -243,8 +243,10 @@ class AccountAnalyticAccount(orm.Model):
                 new_date = next_date + relativedelta(days=+interval)
             elif contract.recurring_rule_type == 'weekly':
                 new_date = next_date + relativedelta(weeks=+interval)
-            else:
+            elif contract.recurring_rule_type == 'monthly':
                 new_date = next_date + relativedelta(months=+interval)
+            else:
+                new_date = next_date+relativedelta(years=+interval)
             context['old_date'] = old_date
             context['next_date'] = new_date
             # Force company for correct evaluate domain access rules

--- a/project_functional_block/project_view.xml
+++ b/project_functional_block/project_view.xml
@@ -4,7 +4,6 @@
         <record id="view_task_functional_block_form" model="ir.ui.view">
             <field name="name">project.task.functional_block.form</field>
             <field name="model">project.task</field>
-            <field name="type">form</field>
             <field name="inherit_id" ref="project.view_task_form2"/>
             <field name="arch" type="xml">
                 <xpath expr="/form/sheet/group/group/field[@name='progress']" position="after">
@@ -16,7 +15,6 @@
         <record id="view_task_tree2" model="ir.ui.view">
             <field name="name">project.task.tree.functional_block</field>
             <field name="model">project.task</field>
-            <field name="type">tree</field>
             <field name="inherit_id" ref="project.view_task_tree2"/>
             <field name="arch" type="xml">
                 <field name="user_id" position="after">
@@ -28,7 +26,6 @@
         <record id="view_task_search_form_fb" model="ir.ui.view">
             <field name="name">project.task.functional.search</field>
             <field name="model">project.task</field>
-            <field name="type">search</field>
             <field name="inherit_id" ref="project.view_task_search_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='name']" position="after">
@@ -46,7 +43,6 @@
 		<record id="funct_block_search_view" model="ir.ui.view">
             <field name="name">project.functional.block.search</field>
             <field name="model">project.functional.block</field>
-            <field name="type">search</field>
             <field name="arch" type="xml">
                 <search string="Search software's module">                
                     <separator orientation="vertical"/>                 
@@ -66,7 +62,6 @@
 		<record model="ir.ui.view" id="funct_block_list_view">
 			<field name="name">project.functional.block.list</field>
 			<field name="model">project.functional.block</field>
-			<field name="type">tree</field>
 			<field name="arch" type="xml">
 			   <tree string="Functionality categories" >				
 					<field name="name"/>
@@ -80,7 +75,6 @@
 		<record model="ir.ui.view" id="funct_categ_form_view">
 			<field name="name">project.functional.block.form</field>
 			<field name="model">project.functional.block</field>
-			<field name="type">form</field>
 			<field name="arch" type="xml">
                 <form string="Functional block" version="7.0">
                     <group>
@@ -97,7 +91,6 @@
 		<record model="ir.actions.act_window" id="action_funct_block_list">
 			<field name="name">Functional block list</field>
 			<field name="res_model">project.functional.block</field>
-			<field name="view_type">form</field> 
 			<field name="view_mode">tree,form</field> 
 			<field name="view_id" ref="funct_block_list_view"/>
 			<field name="search_view_id" ref="funct_block_search_view"/>


### PR DESCRIPTION
Recurring contracts can be invoiced based on days, weeks, months or years. The code to actually handle years is missing.

Lines are already present in the 8.0 code on which this code is based.
