### PR TITLE
[FIX][10.0] project_task_add_very_high: add OCA in authors list

### DIFF
--- a/project_task_add_very_high/__manifest__.py
+++ b/project_task_add_very_high/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Project Task Add Very High",
     "summary": "Adds an extra option 'Very High' on tasks",
     "version": "10.0.1.0.0",
-    "author": "Onestein",
+    "author": "Onestein, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Project Management",
     "website": "http://www.onestein.eu",


### PR DESCRIPTION
I remember some time ago there was an automatic check for the mandatory OCA author in manifest.
It seems that check was removed...