### PR TITLE
[FIX] project_issue_task: avoid button breaks form view

### DIFF
--- a/project_issue_task/__openerp__.py
+++ b/project_issue_task/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Project Issue related Tasks',
     'summary': 'Use Tasks to support Issue resolution reports',
-    'version': '9.0.1.0.2',
+    'version': '9.0.1.1.0',
     'category': 'Project Management',
     'author': "Daniel Reis,"
               "Tecnativa, "

--- a/project_issue_task/__openerp__.py
+++ b/project_issue_task/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Project Issue related Tasks',
     'summary': 'Use Tasks to support Issue resolution reports',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.2',
     'category': 'Project Management',
     'author': "Daniel Reis,"
               "Tecnativa, "

--- a/project_issue_task/views/project_issue_view.xml
+++ b/project_issue_task/views/project_issue_view.xml
@@ -8,6 +8,7 @@
         <field name="inherit_id" ref="project_issue.project_issue_form_view"/>
         <field name="arch" type="xml">
             <field name="task_id" position="after">
+                <label string=""/>
                 <button type="object" name="action_create_task" string="Task Report" attrs="{'invisible': [('task_id', '!=', False)]}"/>
             </field>
         </field>


### PR DESCRIPTION
When module project_issue_task is installed, button breaks form and fields decrease in size. 
Information on those fields can not be read.

cc @Tecnativa