### PR TITLE
[FIX] project_issue_task: propagate partner from issue

### DIFF
--- a/project_issue_task/__openerp__.py
+++ b/project_issue_task/__openerp__.py
@@ -5,7 +5,7 @@
 {
     'name': 'Project Issue related Tasks',
     'summary': 'Use Tasks to support Issue resolution reports',
-    'version': '9.0.1.0.0',
+    'version': '9.0.1.0.1',
     'category': 'Project Management',
     'author': "Daniel Reis,"
               "Tecnativa, "

--- a/project_issue_task/models/project_issue.py
+++ b/project_issue_task/models/project_issue.py
@@ -21,6 +21,7 @@ class ProjectIssue(models.Model):
                 raise UserError(_("A Task is already assigned to the Issue!"))
             task_data = {
                 'project_id': rec.project_id.id,
+                'partner_id': rec.partner_id.id,
                 'name': _('Report for %s') % rec.name,
                 'tag_ids': [(6, 0, rec.tag_ids.ids)],
             }


### PR DESCRIPTION
These changes allow user to propagate issue's partner to task when a task is created by clicking task report button.

cc @Tecnativa