### PR TITLE
[UPD] Modified invisible attribute in 'Create Project' button

### DIFF
--- a/sale_order_project/views/sale_view.xml
+++ b/sale_order_project/views/sale_view.xml
@@ -14,7 +14,7 @@
                         <button name="action_create_project" type="object"
                                 string="Create Project" class="oe_inline oe_edit_only"
                                 groups="project.group_project_user"
-                                attrs="{'invisible':['|',('state','!=','draft'),('related_project_id','!=',False)]}" />
+                                attrs="{'invisible':['|',('state','not in',('draft','sent')),('related_project_id','!=',False)]}" />
                     </div>
                 </field>
             </field>


### PR DESCRIPTION
This PR fixes that a Project can be created from a quotation even when it's in Quotation Sent (by mail) state, not only in Draft Quotation state.