### PR TITLE
8.0 [ADD] project issue timesheet matching

### DIFF
--- a/project_issue_sheet_matching/README.rst
+++ b/project_issue_sheet_matching/README.rst
@@ -1,0 +1,62 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+================================
+Project Issue Timesheet Matching
+================================
+
+When timesheet lines are read in from an external source, eg. through the Toggl 
+connector, they are not connected to a project issue. 
+
+This module allows to match timesheet lines to issues.
+
+Usage
+=====
+
+To use this module, go to Human Resources - Timesheet issue matching and match timesheet lines to issues.
+
+Known issues / Roadmap
+======================
+
+* The number of timesheet lines still to be matched is displayed in the menu, but also appears
+  on other menu items leading to timesheet line views.
+* We should find a way to be able to dismiss lines that you don't want to match to an issue.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/hr_timesheet/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Tom Blauwendraat <info@sunflowerweb.nl>
+* Dan Kiplangat <dan@sunflowerweb.nl>
+* Terrence Nzaywa <terrence@sunflowerweb.nl>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/project_issue_sheet_matching/__init__.py
+++ b/project_issue_sheet_matching/__init__.py
@@ -1,0 +1,3 @@
+# -*- encoding: utf-8 -*-
+
+from . import models

--- a/project_issue_sheet_matching/__openerp__.py
+++ b/project_issue_sheet_matching/__openerp__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+{
+    'name': 'Project Issue Timesheet Matching',
+    'version': '8.0.1.0.0',
+    'category': 'Time Tracking',
+    'depends': [
+        'project_issue_sheet',
+        'hr_timesheet_sheet',
+    ],
+    'author': 'Sunflower IT',
+    'license': 'AGPL-3',
+    'website': 'http://sunflowerweb.nl',
+    'data': [
+        'views/hr_analytic_timesheet.xml',
+    ],
+    'installable': True,
+    'application': True,
+ }

--- a/project_issue_sheet_matching/models/__init__.py
+++ b/project_issue_sheet_matching/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- encoding: utf-8 -*-
+
+from . import hr_analytic_timesheet

--- a/project_issue_sheet_matching/models/hr_analytic_timesheet.py
+++ b/project_issue_sheet_matching/models/hr_analytic_timesheet.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2017 Sunflower IT (http://sunflowerweb.nl)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from openerp import models
+
+_logger = logging.getLogger(__name__)
+
+
+class HrAnalyticTimesheet(models.Model):
+    _name = 'hr.analytic.timesheet'
+    _inherit = ['hr.analytic.timesheet', 'ir.needaction_mixin']
+
+    def _needaction_domain_get(self, cr, uid, context=None):
+        if self._needaction:
+            return [('issue_id', '=', False)]
+        return []

--- a/project_issue_sheet_matching/views/hr_analytic_timesheet.xml
+++ b/project_issue_sheet_matching/views/hr_analytic_timesheet.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="hr_timesheet_line_tree_issue" model="ir.ui.view">
+            <field name="name">hr.analytic.timesheet.tree.issue</field>
+            <field name="model">hr.analytic.timesheet</field>
+            <field name="arch" type="xml">
+                <tree editable="top" string="Timesheet Activities">
+                    <field name="date" on_change="on_change_date(date)"/>
+                    <field name="user_id" on_change="on_change_user_id(user_id)" required="1" options='{"no_open": True}'
+                        context="{'default_groups_ref': ['base.group_user']}"/>
+                    <field name="name"/>
+                    <field name="product_id" domain="[('type','=', 'service'),('sale_ok', '=', True)]"/>
+                    <field name="issue_id" domain="[('analytic_account_id','=', account_id)]"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="hr_timesheet_line_search" model="ir.ui.view">
+            <field name="name">hr.analytic.timesheet.search</field>
+            <field name="model">hr.analytic.timesheet</field>
+            <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_search"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='account_id']" position="after">
+                    <separator/>
+                    <filter name="with_issue" string="With Issue" domain="[('issue_id','!=',False)]"/>
+                    <filter name="without_issue" string="Without Issue" domain="[('issue_id','=',False)]"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="act_hr_timesheet_line_issue" model="ir.actions.act_window">
+            <field name="name">Timesheet Issue Matching</field>
+            <field name="type">ir.actions.act_window</field>
+            <field name="res_model">hr.analytic.timesheet</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="context">{
+                'search_default_without_issue': 1,
+                'needaction_menu_ref': ['project_issue_sheet_matching.unmatched_lines']
+            }</field>
+            <field name="search_view_id" ref="hr_timesheet.hr_timesheet_line_search"/>
+            <field name="view_id" ref="hr_timesheet_line_tree_issue"/>
+            <field name="help" type="html">
+              <p class="oe_view_nocontent_create">
+                Click to match timesheet activities to issues.
+              </p><p>
+                A timesheet entry, when entered on a timesheet, is not coupled
+                to an issue by default. This view helps to match the record
+                time entries to Project Issues.
+              </p>
+            </field>
+        </record>
+
+        <menuitem id="menu_hr_timesheet_line_issue"
+                  parent="hr_attendance.menu_hr_time_tracking"
+                  action="act_hr_timesheet_line_issue"/>
+
+    </data>
+</openerp>


### PR DESCRIPTION
When timesheet lines are read in from an external source, eg. through the [Toggl connector](https://github.com/OCA/hr-timesheet/pull/102) are not connected to a project issue. This module allows to match timesheet lines to issues.