### PR TITLE
[IMP] project_task_materials_stock: add default locations to tasks

### DIFF
--- a/project_task_materials_stock/README.rst
+++ b/project_task_materials_stock/README.rst
@@ -26,6 +26,9 @@ Usage
 #. Go to a task, edit, and add materials to be consumed on tab "Materials".
 #. Move task to an stage on consume material are activated and moves and
    analytic lines will be created.
+#. You can define default locations to consume material in tasks and projects.
+   Locations preference order to consume materials is: locations set in tasks
+   first, locations defined in project second and finally standard locations.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/project_task_materials_stock/__openerp__.py
+++ b/project_task_materials_stock/__openerp__.py
@@ -8,7 +8,7 @@
     "name": "Project Task Materials Stock",
     "summary": "Create stock and analytic moves from "
                "record products spent in a Task",
-    "version": "9.0.1.1.0",
+    "version": "9.0.1.2.0",
     "category": "Project Management",
     "author": "Antiun Ingeniería S.L.,"
               "Tecnativa, "

--- a/project_task_materials_stock/i18n/es.po
+++ b/project_task_materials_stock/i18n/es.po
@@ -1,7 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # * project_task_materials_stock
-# 
+#
 # Translators:
 # OCA Transbot <transbot@odoo-community.org>, 2017
 # Antonio Trueba <atgayol@gmail.com>, 2017
@@ -52,18 +52,21 @@ msgstr ""
 
 #. module: project_task_materials_stock
 #: model:ir.model.fields,help:project_task_materials_stock.field_project_project_location_source_id
+#: model:ir.model.fields,help:project_task_materials_stock.field_project_task_location_source_id
 msgid "Default location from which materials are consumed."
-msgstr ""
+msgstr "Ubicación origen predeterminada donde se consumen los materiales."
 
 #. module: project_task_materials_stock
 #: model:ir.model.fields,help:project_task_materials_stock.field_project_project_location_dest_id
+#: model:ir.model.fields,help:project_task_materials_stock.field_project_task_location_dest_id
 msgid "Default location to which materials are consumed."
-msgstr ""
+msgstr "Ubicación destino predeterminada donde se consumen los materiales."
 
 #. module: project_task_materials_stock
 #: model:ir.model.fields,field_description:project_task_materials_stock.field_project_project_location_dest_id
+#: model:ir.model.fields,field_description:project_task_materials_stock.field_project_task_location_dest_id
 msgid "Destination Location"
-msgstr ""
+msgstr "Ubicación destino"
 
 #. module: project_task_materials_stock
 #: selection:project.task,stock_state:0
@@ -80,8 +83,9 @@ msgstr ""
 
 #. module: project_task_materials_stock
 #: model:ir.ui.view,arch_db:project_task_materials_stock.edit_project_consume_material
+#: model:ir.ui.view,arch_db:project_task_materials_stock.view_project_task_form_materials_stock
 msgid "Locations to consume"
-msgstr ""
+msgstr "Ubicaciones donde consumir"
 
 #. module: project_task_materials_stock
 #: model:ir.ui.view,arch_db:project_task_materials_stock.view_project_task_form_materials_stock
@@ -110,6 +114,7 @@ msgstr "Proyecto"
 
 #. module: project_task_materials_stock
 #: model:ir.model.fields,field_description:project_task_materials_stock.field_project_project_location_source_id
+#: model:ir.model.fields,field_description:project_task_materials_stock.field_project_task_location_source_id
 msgid "Source Location"
 msgstr "Ubicación origen"
 

--- a/project_task_materials_stock/models/project.py
+++ b/project_task_materials_stock/models/project.py
@@ -73,6 +73,18 @@ class Task(models.Model):
          ('assigned', 'Assigned'),
          ('done', 'Done')],
         compute='_compute_stock_state', string='Stock State')
+    location_source_id = fields.Many2one(
+        comodel_name='stock.location',
+        string='Source Location',
+        index=True,
+        help='Default location from which materials are consumed.',
+    )
+    location_dest_id = fields.Many2one(
+        comodel_name='stock.location',
+        string='Destination Location',
+        index=True,
+        help='Default location to which materials are consumed.',
+    )
 
     @api.multi
     def unlink_stock_move(self):
@@ -149,9 +161,11 @@ class ProjectTaskMaterials(models.Model):
             'product_uom_qty': self.quantity,
             'origin': self.task_id.name,
             'location_id':
+                self.task_id.location_source_id.id or
                 self.task_id.project_id.location_source_id.id or
                 self.env.ref('stock.stock_location_stock').id,
             'location_dest_id':
+                self.task_id.location_dest_id.id or
                 self.task_id.project_id.location_dest_id.id or
                 self.env.ref('stock.stock_location_customers').id,
         }

--- a/project_task_materials_stock/views/project_view.xml
+++ b/project_task_materials_stock/views/project_view.xml
@@ -43,6 +43,10 @@
             <field name="material_ids" position="replace">
                 <field name="stock_state" invisible="1"/>
                 <field name="consume_material" invisible="1"/>
+                <group string="Locations to consume" name="materials" groups="stock.group_locations">
+                    <field name="location_source_id"/>
+                    <field name="location_dest_id"/>
+                </group>
                 <group string="Materials consumed" groups="project.group_tasks_work_on_tasks">
                     <notebook>
                         <page string="Products">


### PR DESCRIPTION
Add default locations to consume materials.

Preference order is now:

1. Task
2. Project
3. standard locations