### PR TITLE
[FIX] project_double_alias: Get proper reply to address

### DIFF
--- a/project_double_alias/__manifest__.py
+++ b/project_double_alias/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Double alias for project",
     "summary": "Define an alias for tasks and another alias for issues",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Project management",
     "website": "https://www.tecnativa.com/",
     "author": "Tecnativa, "

--- a/project_double_alias/models/__init__.py
+++ b/project_double_alias/models/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-# © 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.html).
 
+from . import mail_alias
+from . import project_issue
 from . import project_project
+from . import project_task

--- a/project_double_alias/models/mail_alias.py
+++ b/project_double_alias/models/mail_alias.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.html).
+
+from odoo import api, models
+
+
+class MailAlias(models.Model):
+    _inherit = 'mail.alias'
+
+    @api.model
+    def search(self, args, offset=0, limit=None, order=None, count=False):
+        if self.env.context.get('alias_model_search'):
+            model = self.env.context['alias_model_search']
+            args.insert(0, ('alias_model_id.model', '=', model))
+        return super(MailAlias, self).search(
+            args, offset=offset, limit=limit, order=order, count=count,
+        )

--- a/project_double_alias/models/project_issue.py
+++ b/project_double_alias/models/project_issue.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.html).
+
+from odoo import api, models
+
+
+class ProjectIssue(models.Model):
+    _inherit = 'project.issue'
+
+    @api.model
+    def message_get_reply_to(self, res_ids, default=None):
+        return super(
+            ProjectIssue, self.with_context(alias_model_search=self._name),
+        ).message_get_reply_to(res_ids, default=default)

--- a/project_double_alias/models/project_task.py
+++ b/project_double_alias/models/project_task.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl-3.html).
+
+from odoo import api, models
+
+
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+
+    @api.model
+    def message_get_reply_to(self, res_ids, default=None):
+        return super(
+            ProjectTask, self.with_context(alias_model_search=self._name),
+        ).message_get_reply_to(res_ids, default=default)


### PR DESCRIPTION
In v10, the reply to address is not properly caught when having several aliases for the same parent model. We inject a condition in the alias search for avoiding the problem.

cc  @Tecnativa