### PR TITLE
8.0 project definition

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,3 +1,4 @@
 # List the OCA project dependencies, one per line
 # Add a repository url and branch if you need a forked version
 account-analytic
+knowledge

--- a/project_definition/README.rst
+++ b/project_definition/README.rst
@@ -1,0 +1,54 @@
+. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+    :alt: License: AGPL-3
+
+============================
+Term definitions in projects
+============================
+
+Adds a new document page type "Term" to create dictionary-style word archive and
+definition. 
+Adds Searchable view for terms and definitions in the Knowledge menu.
+Has a search view per term and per definition and a dictionary Style Alphabetical grouping view.
+Shows term definitions on every project. just adds a relation between
+document_definition  and project models and adds a tab to the project view.
+
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/project/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Giovanni Francesco Capalbo <giovanni@therp.nl>
+* Holger Brunn <hbrunn@therp.nl>
+
+Do not contact contributors directly about help with questions or problems concerning this addon, but use the `community mailing list <mailto:community@mail.odoo.com>`_ or the `appropriate specialized mailinglist <https://odoo-community.org/groups>`_ for help, and the bug tracker linked in `Bug Tracker`_ above for technical issues.
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/project_definition/__init__.py
+++ b/project_definition/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import models

--- a/project_definition/__openerp__.py
+++ b/project_definition/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Term Definitions in projects",
+    "version": "8.0.1.0.0",
+    "author": "Therp BV,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "",
+    "summary": "",
+    "depends": [
+        'project',
+        'document_page',
+    ],
+    "data": [
+        'views/templates.xml',
+    ],
+    "installable": True,
+}

--- a/project_definition/models/__init__.py
+++ b/project_definition/models/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import project_project
+from . import document_page

--- a/project_definition/models/document_page.py
+++ b/project_definition/models/document_page.py
@@ -17,6 +17,11 @@ class DocumentPage(models.Model):
     # need to be stored in order to use grouping
     first_letter = fields.Char(compute='_get_first_letter', store=True)
 
+    project_id = fields.Many2one(
+        'project.project',
+        'Project'
+    )
+
     @api.depends('name')
     @api.multi
     def _get_first_letter(self):

--- a/project_definition/models/document_page.py
+++ b/project_definition/models/document_page.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, fields, models
+
+
+class DocumentPage(models.Model):
+    _inherit = 'document.page'
+
+    # a relation to partner_id is given by our dependency on
+    # document_page_partner_id if there is no partner_id and no project_id
+    # specified the term is global
+
+    type = fields.Selection(selection_add=[('term', 'Term')])
+
+    # stored compute field used for making the letter grouping
+    # need to be stored in order to use grouping
+    first_letter = fields.Char(compute='_get_first_letter', store=True)
+
+    @api.depends('name')
+    @api.multi
+    def _get_first_letter(self):
+        for this in self:
+            # if somehow the user starts with one or more whitespaces we trim
+            this.first_letter = this.name.lstrip()[:1].upper() or 'Unknown'

--- a/project_definition/models/project_project.py
+++ b/project_definition/models/project_project.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# © 2017 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import fields, models
+
+
+class ProjectProject(models.Model):
+    _inherit = 'project.project'
+
+    term_ids = fields.Many2many(
+        'document.page',
+        domain=[('type', '=', 'term')],
+        string='Project Terms'
+    )

--- a/project_definition/views/templates.xml
+++ b/project_definition/views/templates.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+        <record id="project_term" model="ir.ui.view">
+            <field name="name">project.project.term.form</field>
+            <field name="model">project.project</field>
+            <field name="inherit_id" ref="project.edit_project" />
+            <field name="arch" type="xml">
+                <xpath expr="/form/sheet/notebook/page[@string='Other Info']" position="after">
+                    <page string="Definitions">
+                        <field 
+                            name="term_ids" 
+			    context="{'form_view_ref' : 'project_definition.view_definition_form', 'tree_view_ref': 'project_definition.view_definition_tree',  'active_model': 'project.project'}">
+			    <tree>
+				    <field name="name"/>
+				    <field name="content"/>
+				    <field name="type" readonly="1"/>
+			     </tree>
+                        </field>
+                    </page>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_definition_tree" model="ir.ui.view">
+            <field name="name">document.definition.tree</field>
+            <field name="model">document.page</field>
+            <field name="priority">100</field>
+            <field name="arch" type="xml">
+                <tree string="Definitions" editable="top" >
+                    <field name="name"/>
+                    <field name="content"/>
+                    <field name="type" readonly="1"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="view_definition_form" model="ir.ui.view">
+            <field name="name">document.definition.form</field>
+            <field name="model">document.page</field>
+            <field name="priority">100</field>
+            <field name="arch" type="xml">
+                <form string="Definitions">
+                    <sheet>
+                        <div invisible="context.get('active_model') != 'project.project'"  class=".oe_form_box_warning">
+                            <h3 style="color: red">
+                                The editing of terms is not project-specific. Editing a term will change it globally
+                            </h3>
+                        </div>
+                        <h1>
+                            <field name="name"/>
+                        </h1>
+                        <field name="content"/>
+                        <field name="type" readonly="1"/>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <!-- filters to group by alphabetical order, and search by term or in
+         definition -->
+
+        <record id="view_definition_filter" model="ir.ui.view">
+            <field name="name">document.definition.search</field>
+            <field name="model">document.page</field>
+            <field name="priority">100</field>
+            <field name="arch" type="xml">
+                <search string="Definitions">
+                    <field name="name" string="Search Term" filter_domain="[('name','ilike',self)]"/>
+                    <field name="content" string="Search in definition" filter_domain="[('content','ilike',self)]"/>
+                    <field name="write_uid"/>
+                    <group expand="1" string="Group By...">
+                        <filter string="Alphabetical" domain="[]" context="{'group_by':'first_letter'}"/>
+                        <filter string="Author" domain="[]" context="{'group_by':'create_uid'}"/>
+                        <filter string="Last Contributor" domain="[]" context="{'group_by':'write_uid'}"/>
+                    </group>
+                </search>
+            </field>
+        </record>
+
+        <record id="action_definition" model="ir.actions.act_window">
+            <field name="name">Terms and definitions</field>
+            <field name="res_model">document.page</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">tree,form</field>
+            <field name="view_id" ref="project_definition.view_definition_tree"/>
+            <field name="search_view_id" ref="project_definition.view_definition_filter"/>
+            <field name="domain">[('type', '=', 'term')]</field>
+            <field name="context">{'default_type':'term'}</field>
+        </record>
+
+        <menuitem 
+            id="menu_definition_top"
+            parent="knowledge.menu_document"                 
+            name="Definitions"
+            sequence="22" />
+
+        <menuitem 
+            id="menu_definition"
+            parent="menu_definition_top"                 
+            name="Definitions"
+            action="action_definition"
+            sequence="10" />
+
+    </data>
+</openerp>

--- a/project_definition/views/templates.xml
+++ b/project_definition/views/templates.xml
@@ -10,11 +10,12 @@
                     <page string="Definitions">
                         <field 
                             name="term_ids" 
-			    context="{'form_view_ref' : 'project_definition.view_definition_form', 'tree_view_ref': 'project_definition.view_definition_tree',  'active_model': 'project.project'}">
+                            context="{'form_view_ref' : 'project_definition.view_definition_form', 'tree_view_ref': 'project_definition.view_definition_tree',  'active_model': 'project.project', 'default_project_id': active_id }">
 			    <tree>
 				    <field name="name"/>
 				    <field name="content"/>
-				    <field name="type" readonly="1"/>
+                    <field name="type" readonly="1"/>
+                    <field name="project_id" readonly="1" />
 			     </tree>
                         </field>
                     </page>
@@ -31,6 +32,8 @@
                     <field name="name"/>
                     <field name="content"/>
                     <field name="type" readonly="1"/>
+                    <field name="project_id" />
+
                 </tree>
             </field>
         </record>
@@ -50,8 +53,11 @@
                         <h1>
                             <field name="name"/>
                         </h1>
-                        <field name="content"/>
-                        <field name="type" readonly="1"/>
+                        <group>
+                           <field name="content"/>
+                           <field name="project_id" />
+                           <field name="type" readonly="1"/>
+                        </group>
                     </sheet>
                 </form>
             </field>


### PR DESCRIPTION
Adds a new document page type "Term" to create dictionary-style word archive and
definition.  Adds Searchable view  and menu for "terms and definitions" in the Knowledge menu.
Has a search view per term and per definition and a dictionary Style Alphabetical grouping view.

Shows term definitions on every project.  just adds a relation between
document_page of type "term"  and project models and adds a tab to the project view.

