### PR TITLE
[FIX] project_timesheet_time_control: Condition always gets evaluated as False

### DIFF
--- a/project_timesheet_time_control/__manifest__.py
+++ b/project_timesheet_time_control/__manifest__.py
@@ -6,7 +6,7 @@
 
 {
     'name': 'Project timesheet time control',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Project',
     'author': 'Tecnativa,'
               'Odoo Community Association (OCA)',

--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -32,7 +32,7 @@ class AccountAnalyticLine(models.Model):
             self.project_id = self.task_id.project_id.id
 
     def eval_date(self, vals):
-        if vals.get('date_time', False):
+        if 'date_time' in vals and vals.get('date_time'):
             vals['date'] = fields.Date.from_string(vals['date_time'])
         return vals
 

--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -32,7 +32,7 @@ class AccountAnalyticLine(models.Model):
             self.project_id = self.task_id.project_id.id
 
     def eval_date(self, vals):
-        if 'date_time' in vals and 'date' not in vals:
+        if vals.get('date_time', False):
             vals['date'] = fields.Date.from_string(vals['date_time'])
         return vals
 

--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -32,7 +32,7 @@ class AccountAnalyticLine(models.Model):
             self.project_id = self.task_id.project_id.id
 
     def eval_date(self, vals):
-        if 'date_time' in vals and vals.get('date_time'):
+        if vals.get('date_time'):
             vals['date'] = fields.Date.from_string(vals['date_time'])
         return vals
 


### PR DESCRIPTION
Hello,

We've notice that if a new analytic line is created with a date_time different from today. The field date is never equals to field date_time, because date has a [default value](https://github.com/odoo/odoo/blob/10.0/addons/analytic/models/analytic_account.py#L97) defined at analytic module. So the condition in eval_date function is always evaluated as False