### PR TITLE
[11.0][FIX] project_closing: "E501 line too long"

### DIFF
--- a/project_closing/models/analytic.py
+++ b/project_closing/models/analytic.py
@@ -6,6 +6,8 @@ class AnalyticAccount(models.Model):
 
     @api.multi
     def toggle_active(self):
-        for analytic in self.with_context(doing_project_toggle_active=True, active_test=False):
+        for analytic in self.with_context(
+                doing_project_toggle_active=True,
+                active_test=False):
             analytic.project_ids.toggle_active()
         return super(AnalyticAccount, self).toggle_active()


### PR DESCRIPTION
The pull request https://github.com/OCA/project/pull/343 actually fails because of a flake8 error on module `project_closing`.
