### PR TITLE
[FIX][10.0] project_task_dependency: avoid recursion

### DIFF
--- a/project_task_dependency/__manifest__.py
+++ b/project_task_dependency/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Project Task Dependencies',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Project',
     'summary': 'Enables to define dependencies (other tasks) of a task',
     'author': "Onestein,Odoo Community Association (OCA)",

--- a/project_task_dependency/models/project_task.py
+++ b/project_task_dependency/models/project_task.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-# © 2016 Onestein (<http://www.onestein.eu>)
+# Copyright 2016-2018 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProjectTask(models.Model):
@@ -62,3 +63,8 @@ class ProjectTask(models.Model):
                 for t in depending_tasks:
                     depending_tasks += self.get_depending_tasks(t, recursive)
             return depending_tasks
+
+    @api.constrains('dependency_task_ids')
+    def _check_recursion(self):
+        if not self._check_m2m_recursion('dependency_task_ids'):
+            raise ValidationError(_('You cannot create recursive tasks.'))

--- a/project_task_dependency/tests/test_project_task_dependency.py
+++ b/project_task_dependency/tests/test_project_task_dependency.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-# © 2016 Onestein (<http://www.onestein.eu>)
+# Copyright 2016-2018 Onestein (<http://www.onestein.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -21,7 +22,7 @@ class TestProjectTaskDependency(TransactionCase):
             'dependency_task_ids': [(6, 0, [self.task2.id])]
         })
 
-    def test_dependency_path(self):
+    def test_01_dependency_path(self):
         self.assertEqual(len(self.task3.dependency_task_ids), 1)
 
         self.assertEqual(len(self.task1.recursive_dependency_task_ids), 0)
@@ -32,3 +33,9 @@ class TestProjectTaskDependency(TransactionCase):
 
         self.assertEqual(len(self.task3.recursive_depending_task_ids), 0)
         self.assertEqual(len(self.task1.recursive_depending_task_ids), 2)
+
+    def test_02_avoid_recursion(self):
+        with self.assertRaises(ValidationError):
+            self.task1.write({
+                'dependency_task_ids': [(6, 0, [self.task3.id])]
+            })


### PR DESCRIPTION
This PR is a proposal of a fix for issue https://github.com/OCA/project/issues/332.

This proposed fix just prevents the user to create recursions in the task dependency graph.

In case a recursion was already created in the past, that recursion will be NOT removed/fixed by just updating this module. To remove a recursion that was already created, the user must do it manually in the database.