### PR TITLE
[FIX] for warning during the odoo build that module is not installable

### DIFF
--- a/project_timesheet_analytic_partner/__manifest__.py
+++ b/project_timesheet_analytic_partner/__manifest__.py
@@ -17,5 +17,5 @@
         'project_timesheet',
     ],
     'installable': False,
-    "auto_install": True,
+    "auto_install": False,
 }


### PR DESCRIPTION
Fixes the annoying warning that the module is not installable.