### PR TITLE
[FIX] Fix dependency recursion error due to upstream changes in odoo

### DIFF
--- a/project_task_dependency/__manifest__.py
+++ b/project_task_dependency/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'Project Task Dependencies',
-    'version': '11.0.1.0.0',
+    'version': '11.0.1.0.1',
     'category': 'Project',
     'summary': 'Enables to define dependencies (other tasks) of a task',
     'author': "Onestein,Odoo Community Association (OCA)",

--- a/project_task_dependency/models/project_task.py
+++ b/project_task_dependency/models/project_task.py
@@ -67,6 +67,8 @@ class ProjectTask(models.Model):
             return depending_tasks
 
     @api.constrains('dependency_task_ids')
-    def _check_recursion(self):
+    def _check_dependency_recursion(self):
         if not self._check_m2m_recursion('dependency_task_ids'):
-            raise ValidationError(_('You cannot create recursive tasks.'))
+            raise ValidationError(
+                _('You cannot create recursive dependencies between tasks.')
+            )


### PR DESCRIPTION
Due to a recent commit in upstream Odoo https://github.com/odoo/odoo/commit/e5fb990db1d6216a156617e387d85d13c1a0b93c the name of the method used in this module to check recursion overrides the original one and generates an error when setting subtasks. To avoid overlapping I renamed the method and changed the description slightly.