### PR TITLE
[11.0][FIX] project_timeline: Unsetting date_end

### DIFF
--- a/project_timeline/models/project_task.py
+++ b/project_timeline/models/project_task.py
@@ -18,3 +18,9 @@ class ProjectTask(models.Model):
         super(ProjectTask, self)._onchange_user()
         if old_date_start > self.date_start:
             self.date_start = old_date_start
+
+    def update_date_end(self, stage_id):
+        if self.ids:
+            return {}
+        else:
+            return super(ProjectTask, self).update_end_date(stage_id)

--- a/project_timeline/models/project_task.py
+++ b/project_timeline/models/project_task.py
@@ -20,7 +20,6 @@ class ProjectTask(models.Model):
             self.date_start = old_date_start
 
     def update_date_end(self, stage_id):
-        if self.ids:
-            return {}
-        else:
-            return super(ProjectTask, self).update_end_date(stage_id)
+        res = super(ProjectTask, self).update_date_end(stage_id)
+        res.pop('date_end')
+        return res

--- a/project_timeline/tests/__init__.py
+++ b/project_timeline/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_project_timeline

--- a/project_timeline/tests/test_project_timeline.py
+++ b/project_timeline/tests/test_project_timeline.py
@@ -1,0 +1,20 @@
+# Copyright 2018 Onestein
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProjectTimeline(TransactionCase):
+
+    def test_date_end_doesnt_unset(self):
+        stage_id = self.ref('project.project_stage_2')
+        task = self.env['project.task'].create({
+            'name': '1',
+            'date_start': '2018-05-01 00:00:00',
+            'date_end': '2018-05-07 00:00:00'
+        })
+        task.write({
+            'stage_id': stage_id,
+            'date_end': '2018-10-07 00:00:00'
+        })
+        self.assertEqual(task.date_end, '2018-10-07 00:00:00')


### PR DESCRIPTION
Fixes: https://github.com/OCA/web/issues/989