### PR TITLE
[10.0][ADD] Add sql for migrate the category_id for tasks

### DIFF
--- a/project_task_category/migrations/10.0.1.0.0/pre-migration.py
+++ b/project_task_category/migrations/10.0.1.0.0/pre-migration.py
@@ -29,4 +29,12 @@ def migrate(env, version):
                  );
             """
     openupgrade.logged_query(cr, query)
+
+    update_categ_query = """
+        UPDATE project_task task
+        SET categ_id = categ.id
+        FROM project_category categ, project_category_main categ_main
+        WHERE categ.name = categ_main.name AND task.categ_id = categ_main.id;
+    """
+    openupgrade.logged_query(cr, update_categ_query)
     openupgrade.logging("Migrate project_category done.")


### PR DESCRIPTION
@elicoidal @seb-elico @lonelysun @victormartinelicocorp 

- Add sql to migrate the task category 
- The script should be executed before the module loaded, otherwise there will errors of foreign key constraint for `categ_id` on `project.task`