### PR TITLE
[11.0][FIX] project_key: Copying / duplicating projects

### DIFF
--- a/project_key/models/project_project.py
+++ b/project_key/models/project_project.py
@@ -19,6 +19,7 @@ class Project(models.Model):
         size=10,
         required=False,
         index=True,
+        copy=False
     )
 
     _sql_constraints = [


### PR DESCRIPTION
Currently you can't copy a project because the key is not regenerated. The key must be unique so it throws an error. This PR will prevent the key of being copied to the new project and generate a new key instead.