### PR TITLE
[10.0][FIX]project wbs

### DIFF
--- a/project_wbs/__init__.py
+++ b/project_wbs/__init__.py
@@ -7,3 +7,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from .hooks import pre_init_hook

--- a/project_wbs/__manifest__.py
+++ b/project_wbs/__manifest__.py
@@ -7,7 +7,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Work Breakdown Structure',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'license': 'AGPL-3',
     'author': 'Matmoz d.o.o., '
               'Luxim d.o.o., '
@@ -18,12 +18,14 @@
     'depends': [
         'project',
         'analytic',
-        'account_analytic_parent'
+        'account_analytic_parent',
+        'account_analytic_sequence',
     ],
     'summary': 'Project Work Breakdown Structure',
     'data': [
         'view/account_analytic_account_view.xml',
         'view/project_project_view.xml',
     ],
+    'pre_init_hook': 'pre_init_hook',
     'installable': True,
 }

--- a/project_wbs/hooks.py
+++ b/project_wbs/hooks.py
@@ -1,0 +1,12 @@
+from odoo.api import Environment, SUPERUSER_ID
+import logging
+logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(cr):
+    env = Environment(cr, SUPERUSER_ID, {})
+    # avoid crashing installation because of having same complete_wbs_code
+    for aa in env['account.analytic.account'].search([]):
+        aa.code = env['ir.sequence'].next_by_code(
+            'account.analytic.account.code')
+    logger.info('Assigning default code to existing analytic accounts')

--- a/project_wbs/hooks.py
+++ b/project_wbs/hooks.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from odoo.api import Environment, SUPERUSER_ID
 import logging
 logger = logging.getLogger(__name__)

--- a/project_wbs/hooks.py
+++ b/project_wbs/hooks.py
@@ -4,10 +4,27 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def create_analytic_account(env, projects):
+    for project in projects:
+        analytic_account = env['account.analytic.account'].create({
+            'name': project.name,
+            'company_id': project.company_id.id,
+            'partner_id': project.partner_id.id,
+            'active': True,
+        })
+        project.write({'analytic_account_id': analytic_account.id})
+
+
 def pre_init_hook(cr):
     env = Environment(cr, SUPERUSER_ID, {})
     # avoid crashing installation because of having same complete_wbs_code
-    for aa in env['account.analytic.account'].search([]):
-        aa.code = env['ir.sequence'].next_by_code(
-            'account.analytic.account.code')
+    for aa in env['account.analytic.account'].with_context(
+            active_test=False).search([('code', '=', False)]):
+        aa._write({'code': env['ir.sequence'].next_by_code(
+            'account.analytic.account.code')})
     logger.info('Assigning default code to existing analytic accounts')
+    projects = env["project.project"].with_context(active_test=False).search(
+        [('analytic_account_id', '=', False)])
+    create_analytic_account(env, projects)
+    projects.filtered(lambda p: not p.active).mapped(
+        'analytic_account_id').write({'active': False})

--- a/project_wbs/models/account_analytic_account.py
+++ b/project_wbs/models/account_analytic_account.py
@@ -59,9 +59,10 @@ class AccountAnalyticAccount(models.Model):
                 acc = acc.parent_id
             if data:
                 if len(data) >= 2:
-                    data = '/'.join(data)
+                    data = ' / '.join(data)
                 else:
                     data = data[0]
+                data = '[' + data + '] '
             account.complete_wbs_code = data or ''
 
     @api.multi

--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -95,6 +95,8 @@ class Project(models.Model):
     @api.depends('parent_id')
     def _compute_child(self):
         for project_item in self:
+            if not project_item.analytic_account_id:
+                continue
             child_ids = self.search(
                 [('parent_id', '=', project_item.analytic_account_id.id)]
             )

--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -167,6 +167,7 @@ class Project(models.Model):
             })
         domain.append(('id', 'in', project_ids))
         res.update({
+            "display_name": project.name,
             "domain": domain,
             "nodestroy": False
         })
@@ -204,6 +205,7 @@ class Project(models.Model):
                 "domain": domain,
                 "nodestroy": False
             })
+        res['display_name'] = project.name
         return res
 
     @api.multi

--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -115,6 +115,14 @@ class Project(models.Model):
             return context['default_parent_id']
         return None
 
+    def prepare_analytics_vals(self, vals):
+        return {
+            'name': vals.get('name', _('Unknown Analytic Account')),
+            'company_id': vals.get('company_id', self.env.user.company_id.id),
+            'partner_id': vals.get('partner_id'),
+            'active': True,
+        }
+
     project_child_complete_ids = fields.Many2many(
         comodel_name='project.project',
         string="Project Hierarchy",
@@ -249,7 +257,7 @@ class Project(models.Model):
     @api.multi
     @api.onchange('parent_id')
     def on_change_parent(self):
-        return self.analytic_account_id._onchange_parent_id()
+        self.analytic_account_id._onchange_parent_id()
 
     @api.multi
     def action_open_view_project_form(self):

--- a/project_wbs/tests/test_project_wbs.py
+++ b/project_wbs/tests/test_project_wbs.py
@@ -36,13 +36,13 @@ class TestProjectWbs(common.TransactionCase):
 
     def test_wbs_code(self):
         self.assertEqual(
-            self.project.complete_wbs_code, '0001',
+            str(self.project.complete_wbs_code), '[0001] ',
             'Incorrect WBS code')
         self.assertEqual(
-            self.project_son.complete_wbs_code, '0001/01',
+            str(self.project_son.complete_wbs_code), '[0001 / 01] ',
             'Incorrect WBS code')
         self.assertEqual(
-            self.project_grand_son.complete_wbs_code, '0001/01/02',
+            str(self.project_grand_son.complete_wbs_code), '[0001 / 01 / 02] ',
             'Incorrect WBS code')
 
     def test_get_child_accounts(self):

--- a/project_wbs/tests/test_project_wbs.py
+++ b/project_wbs/tests/test_project_wbs.py
@@ -46,6 +46,8 @@ class TestProjectWbs(common.TransactionCase):
             'Incorrect WBS code')
 
     def test_get_child_accounts(self):
+        res = self.env['account.analytic.account'].get_child_accounts()
+        self.assertEqual(res, {}, 'Should get nothing')
         res = self.parent_account.get_child_accounts()
         for has_parent in res.keys():
             self.assertEqual(res[has_parent], True, 'Wrong child accounts')
@@ -56,6 +58,10 @@ class TestProjectWbs(common.TransactionCase):
             _resolve_analytic_account_id_from_context()
         self.assertEqual(
             res, self.project.id, 'Wrong Parent Project from context')
+        res = self.env['project.project'].\
+            _resolve_analytic_account_id_from_context()
+        self.assertEqual(
+            res, None, 'Should not be anything in context')
 
     def test_indent_calc(self):
         self.son_account._wbs_indent_calc()
@@ -90,3 +96,13 @@ class TestProjectWbs(common.TransactionCase):
         self.project2.write({'parent_id': self.parent_account.id})
         child_in = self.project2 in self.project.project_child_complete_ids
         self.assertTrue(child_in, 'Child not added')
+
+    def test_duplicate(self):
+        seq_id = self.env['ir.sequence'].search(
+            [('code', '=', 'account.analytic.account.code')])
+        next_val = seq_id.number_next_actual
+        copy_project = self.project.copy()
+        self.assertTrue(str(next_val) in copy_project.analytic_account_id.code)
+        next_val = seq_id.number_next_actual
+        copy_analytic = self.parent_account.copy()
+        self.assertTrue(str(next_val) in copy_analytic.code)

--- a/project_wbs/view/account_analytic_account_view.xml
+++ b/project_wbs/view/account_analytic_account_view.xml
@@ -17,7 +17,6 @@
                     <field name="user_id" invisible="1"/>
                     <field name="manager_id"/>
                     <field name="parent_id" invisible="1"/>
-                    <field name="state" invisible="1"/>
                     <field name="account_class" invisible="1"/>
                     <field name="complete_wbs_code" string="WBS code"/>
                     <field name="project_analytic_id"

--- a/project_wbs/view/project_project_view.xml
+++ b/project_wbs/view/project_project_view.xml
@@ -28,7 +28,7 @@
                     <div class="oe_wbs_subtitle">
                         <div class="parentheading">
                             <field name="account_class"/>
-                            <field name="complete_wbs_code"/>
+                            <field name="c_wbs_code"/>
                         </div>
                     </div>
                     </a>
@@ -61,10 +61,10 @@
                 <xpath expr='//tree' position="attributes">
                     <attribute name="editable">top</attribute>
                     <attribute name="decoration-primary">account_class == 'project'</attribute>
-                    <attribute name="default_order">complete_wbs_code</attribute>
+                    <attribute name="default_order">c_wbs_code</attribute>
                 </xpath>
                 <xpath expr='//field[@name="sequence"]' position="after">
-                    <field name="complete_wbs_code" string="Code"/>
+                    <field name="c_wbs_code" string="Code"/>
                     <field name="wbs_indent"/>
                     <button string="Parent WBS element"
                         name="action_open_parent_tree_view"
@@ -103,7 +103,7 @@
             <field name="arch" type="xml">
                 <field name="name" position="after">
                     <field name="complete_wbs_name" string="WBS name"/>
-                    <field name="complete_wbs_code" string="WBS code"/>
+                    <field name="c_wbs_code" string="WBS code"/>
                     <field name="account_class" string="Class"/>
                     <field name="project_analytic_id"
                            domain="[('account_class', '=', 'project')]"/>
@@ -167,7 +167,7 @@
                     <field name="project_analytic_id"
                            domain="[('account_class', '=', 'project')]"/>
                     <field name="code" string="Code"/>
-                    <field name="complete_wbs_code" string="WBS code" readonly="1" />
+                    <field name="c_wbs_code" string="WBS code" readonly="1" />
                 </xpath>
 
                 <notebook position="inside">


### PR DESCRIPTION
- complete_wbs_code in projects are not correct, they show the code not the full wbs code
- duplicated complete_wbs_code should not be allowed
- includes hook to avoid breaking previous condition
- recomputes wbs codes for all the hierarchy when changing the parent.
- includes fix on complete_wbs_code calculation
- improve test coverage
- fixes showing all projects without analytic account on children creation (only happens on migrated DBs but better cover the case)

**All fixes here are merged to 11.0**