### PR TITLE
[11.0][FIX] Fix name of project.task and project.task.type model files

### DIFF
--- a/project_stage_state/models/project_task.py
+++ b/project_stage_state/models/project_task.py
@@ -4,14 +4,7 @@
 from odoo import models, fields
 
 
-_TASK_STATE = [
-    ('draft', 'New'),
-    ('open', 'In Progress'),
-    ('pending', 'Pending'),
-    ('done', 'Done'),
-    ('cancelled', 'Cancelled')]
-
-
-class ProjectTaskType(models.Model):
-    _inherit = 'project.task.type'
-    state = fields.Selection(_TASK_STATE, 'State')
+class ProjectTask(models.Model):
+    _inherit = 'project.task'
+    state = fields.Selection(
+        related='stage_id.state', store=True, readonly=True)

--- a/project_stage_state/models/project_task_type.py
+++ b/project_stage_state/models/project_task_type.py
@@ -4,7 +4,14 @@
 from odoo import models, fields
 
 
-class ProjectTask(models.Model):
-    _inherit = 'project.task'
-    state = fields.Selection(
-        related='stage_id.state', store=True, readonly=True)
+_TASK_STATE = [
+    ('draft', 'New'),
+    ('open', 'In Progress'),
+    ('pending', 'Pending'),
+    ('done', 'Done'),
+    ('cancelled', 'Cancelled')]
+
+
+class ProjectTaskType(models.Model):
+    _inherit = 'project.task.type'
+    state = fields.Selection(_TASK_STATE, 'State')


### PR DESCRIPTION
The `project.task` and `project.task.type` models has wrong file names.