### PR TITLE
[10.0][IMP]project_wbs. Propagate active from the hierarchy

### DIFF
--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -256,3 +256,9 @@ class Project(models.Model):
             'context': self.env.context
         }
         return view
+
+    @api.multi
+    def write(self, vals):
+        if 'active' in vals:
+            self.mapped('project_child_complete_ids').toggle_active()
+        return super(Project, self).write(vals)

--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -264,8 +264,9 @@ class Project(models.Model):
             if (project.active and project.parent_id and not
                     project.parent_id.active):
                 raise exceptions.ValidationError(
-                    _('Please activate first parent project')
-                    % self.parent_id.display_name)
+                    _('Please activate first parent project %s')
+                    % project.parent_id.display_name)
+        return True
 
     @api.multi
     def archive_project(self):

--- a/project_wbs/tests/test_project_wbs.py
+++ b/project_wbs/tests/test_project_wbs.py
@@ -6,6 +6,7 @@
 # Copyright 2017 Serpent Consulting Services Pvt. Ltd.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from odoo.tests import common
+from odoo.exceptions import ValidationError
 
 
 class TestProjectWbs(common.TransactionCase):
@@ -95,4 +96,7 @@ class TestProjectWbs(common.TransactionCase):
         self.project.toggle_active()
         self.assertEqual(self.project_grand_son.active, False)
         self.project.toggle_active()
-        self.assertEqual(self.project_grand_son.active, True)
+        self.assertEqual(self.project_grand_son.active, False)
+        self.project.toggle_active()
+        with self.assertRaises(ValidationError):
+            self.project_grand_son.toggle_active()

--- a/project_wbs/tests/test_project_wbs.py
+++ b/project_wbs/tests/test_project_wbs.py
@@ -90,3 +90,9 @@ class TestProjectWbs(common.TransactionCase):
         self.project2.write({'parent_id': self.parent_account.id})
         child_in = self.project2 in self.project.project_child_complete_ids
         self.assertTrue(child_in, 'Child not added')
+
+    def test_archive(self):
+        self.project.toggle_active()
+        self.assertEqual(self.project_grand_son.active, False)
+        self.project.toggle_active()
+        self.assertEqual(self.project_grand_son.active, True)


### PR DESCRIPTION
As this module uses the hierarchy proposed by the analytic account it is likely that users set the analytic account to archived instead of the project. In this case the project remains active and can be confusing for project users. It makes sense to close all the projects related when the analytic account is closed.