### PR TITLE
[12.0][IMP] project_key: do not regenerate project key if it's already set

### DIFF
--- a/project_key/models/project_project.py
+++ b/project_key/models/project_project.py
@@ -30,6 +30,9 @@ class Project(models.Model):
     @api.onchange('name')
     def _onchange_project_name(self):
         for rec in self:
+            if rec.key:
+                continue
+
             if rec.name:
                 rec.key = self.generate_project_key(rec.name)
             else:

--- a/project_key/tests/test_project.py
+++ b/project_key/tests/test_project.py
@@ -58,3 +58,11 @@ class TestProject(TestCommon):
     def test_08_generate_empty_project_key(self):
         empty_key = self.Project.generate_project_key(False)
         self.assertEqual(empty_key, '')
+
+    def test_09_name_onchange_with_key(self):
+        project = self.Project.new({
+            'name': 'Software Development',
+            'key': 'TEST',
+        })
+        project._onchange_project_name()
+        self.assertEqual(project.key, 'TEST')


### PR DESCRIPTION
In case project key is already generated or set manually, do not overwrite it