### PR TITLE
[10.0][FIX] project_model_to_task compute method name

### DIFF
--- a/project_model_to_task/__manifest__.py
+++ b/project_model_to_task/__manifest__.py
@@ -7,6 +7,7 @@
     'version': '10.0.0.1.0',
     'category': 'project',
     'author': 'Akretion, Odoo Community Association (OCA)',
+    'license': 'AGPL-3',
     'depends': [
         'project',
     ],

--- a/project_model_to_task/models/project.py
+++ b/project_model_to_task/models/project.py
@@ -12,7 +12,7 @@ class ProjectTask(models.Model):
 
     @api.multi
     @api.depends('model_reference')
-    def _get_origin(self):
+    def _compute_task_origin(self):
         for rec in self:
             if rec.model_reference and rec.model_reference._rec_name:
                 rec.task_origin = rec.model_reference.display_name or False
@@ -32,7 +32,7 @@ class ProjectTask(models.Model):
         help="Action called to go to the original window.")
     model_reference = fields.Reference(
         selection='_authorised_models')
-    task_origin = fields.Char(compute='_get_origin')
+    task_origin = fields.Char(compute='_compute_task_origin')
 
     @api.model
     def default_get(self, fields):


### PR DESCRIPTION
fix of compute method name & missing license in manifest