### PR TITLE
[FIX][12.0] project_key relative path

### DIFF
--- a/project_key/tests/test_controller.py
+++ b/project_key/tests/test_controller.py
@@ -3,7 +3,7 @@
 
 from mock import patch
 from odoo import http
-from odoo.addons.project_key.controllers.main import ProjectBrowser
+from ..controllers.main import ProjectBrowser
 from .test_common import HttpTestCommon
 
 


### PR DESCRIPTION
fix project_key/tests/test_controller.py:6: [W7950(odoo-addons-relative-import), ] Same Odoo module absolute import. You should use relative import with "." instead of "openerp.addons.project_key"