### PR TITLE
[FIX][12.0] project_task_code missing api.multi

### DIFF
--- a/project_task_code/models/project_task.py
+++ b/project_task_code/models/project_task.py
@@ -31,7 +31,9 @@ class ProjectTask(models.Model):
                 )
         return super().create(vals_list)
 
+    @api.multi
     def copy(self, default=None):
+        self.ensure_one()
         if default is None:
             default = {}
         default['code'] = self.env['ir.sequence'].next_by_code('project.task')


### PR DESCRIPTION
fix of
project_task_code/models/project_task.py:34: [W8102(copy-wo-api-one), ProjectTask.copy] Missing api.one or api.multi in copy function.