### PR TITLE
project_tag UX: move tags field to title of form

### DIFF
--- a/project_tag/views/project.xml
+++ b/project_tag/views/project.xml
@@ -24,11 +24,14 @@
     <field name="inherit_id" ref="project.edit_project"/>
     <field name="type">form</field>
     <field name="arch" type="xml">
-      <field name="privacy_visibility" position="before">
-        <field name="tag_ids"
-               widget="many2many_tags"
-               options="{'color_field': 'color'}"/>
-      </field>
+      <xpath expr="//div[hasclass('oe_title')]/h1[./field[@name='name']]" position="after">
+        <h4>
+            <field name="tag_ids"
+                   placeholder="Tags..."
+                   widget="many2many_tags"
+                   options="{'color_field': 'color'}"/>
+        </h4>
+      </xpath>
     </field>
   </record>
 


### PR DESCRIPTION
#### Before this PR
Tags are displayed inside *Settings* page of notebook on form view:
![image](https://user-images.githubusercontent.com/1129820/62537410-00691e80-b859-11e9-8be5-9d372b6cda6c.png)
#### After this PR
Tags are displayed inside title of form:
![image](https://user-images.githubusercontent.com/1129820/62537463-1bd42980-b859-11e9-8398-16202e4b754d.png)

