### PR TITLE
project_status UX: add default_group_by and group_expand

### DIFF
--- a/project_status/models/project.py
+++ b/project_status/models/project.py
@@ -1,7 +1,16 @@
-from odoo import models, fields
+from odoo import models, fields, api, SUPERUSER_ID
 
 
 class Project(models.Model):
     _inherit = 'project.project'
 
-    project_status = fields.Many2one('project.status', string="Project Status")
+    @api.model
+    def _read_group_status_ids(self, statuses, domain, order):
+        statuse_ids = statuses._search(
+            [], order=order, access_rights_uid=SUPERUSER_ID)
+        return statuses.browse(statuse_ids)
+
+    project_status = fields.Many2one(
+        'project.status', string="Project Status",
+        group_expand='_read_group_status_ids', copy=False,
+        ondelete='restrict', index=True)

--- a/project_status/views/project.xml
+++ b/project_status/views/project.xml
@@ -54,6 +54,9 @@
     <field name="inherit_id" ref="project.view_project_kanban"/>
     <field name="arch" type="xml">
       <data>
+        <xpath expr="/kanban" position="attributes">
+          <attribute name="default_group_by">project_status</attribute>
+        </xpath>
         <xpath expr="//div[hasclass('o_primary')]" position="after">
           <div>
             <t t-if="record.project_status.raw_value">


### PR DESCRIPTION
#### Before this PR
- Project status could be changed  only inside form view.
- unintuitive project statuses on kanban view

![image](https://user-images.githubusercontent.com/1129820/62538785-54293700-b85c-11e9-99dd-0844e134d8a5.png)

#### After this PR
- Projects are grouped by project status by default
- Project's status could be changed from kanban view

![image](https://user-images.githubusercontent.com/1129820/62538863-820e7b80-b85c-11e9-9989-955f08558228.png)
