### PR TITLE
[12.0][FIX] project_hr: domain on field breaks other modules

### DIFF
--- a/project_hr/models/project_task.py
+++ b/project_hr/models/project_task.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Tecnativa - Pedro M. Baeza
+# Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, exceptions, fields, models
@@ -20,9 +21,6 @@ class ProjectTask(models.Model):
         help="Here you can select the employee category suitable to perform "
              "this task, limiting the selectable users to be assigned to "
              "those that belongs to that category.",
-    )
-    user_id = fields.Many2one(
-        domain="[('id', 'in', allowed_user_ids)]",
     )
     allowed_hr_category_ids = fields.Many2many(
         comodel_name="hr.employee.category",

--- a/project_hr/readme/CONTRIBUTORS.rst
+++ b/project_hr/readme/CONTRIBUTORS.rst
@@ -2,3 +2,5 @@
 
   * Pedro M. Baeza
   * Victor M.M. Torres
+
+* Alexey Pelykh <alexey.pelykh@brainbeanapps.com>

--- a/project_hr/views/project_task_views.xml
+++ b/project_hr/views/project_task_views.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright 2018 Tecnativa - Pedro M. Baeza
+     Copyright 2019 Brainbean Apps (https://brainbeanapps.com)
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 
 <odoo>
@@ -14,8 +15,39 @@
                 <field name="allowed_user_ids" invisible="1"/>
                 <field name="hr_category_ids" widget="many2many_tags"/>
             </field>
+            <field name="user_id" position="attributes">
+                <attribute name="domain">[('id', 'in', allowed_user_ids)]</attribute>
+            </field>
             <field name="date_assign" position="after">
                 <field name="employee_id"/>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="quick_create_task_form">
+        <field name="name">project.task.form.quick_create</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.quick_create_task_form"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="before">
+                <field name="allowed_user_ids" invisible="1"/>
+            </field>
+            <field name="user_id" position="attributes">
+                <attribute name="domain">[('id', 'in', allowed_user_ids)]</attribute>
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_task_tree2">
+        <field name="name">project.task.tree</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_tree2"/>
+        <field name="arch" type="xml">
+            <field name="user_id" position="before">
+                <field name="allowed_user_ids" invisible="1"/>
+            </field>
+            <field name="user_id" position="attributes">
+                <attribute name="domain">[('id', 'in', allowed_user_ids)]</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
W/o this fix any module that would inherit views that include `user_id` field of `project.task` and won't depend on `project_hr` - will have failing builds