### PR TITLE
[IMP] project_timesheet_time_control: ❤️ 4 UX

### DIFF
--- a/project_timesheet_time_control/README.rst
+++ b/project_timesheet_time_control/README.rst
@@ -25,10 +25,9 @@ Project timesheet time control
 
 |badge1| |badge2| |badge3| |badge4| |badge5| 
 
-* This module adds a button at account analytic line level to compute the spent
-  time, in minutes, from start date to the current moment.
-* It adds a datetime field that replaces ``date`` field in tree view, and write
-  date field with datetime field value.
+Allow to track the exact moment when a timesheet line is started (not only
+the day, but also the minute and second) and let users start and stop timers
+easily.
 
 **Table of contents**
 
@@ -38,9 +37,10 @@ Project timesheet time control
 Installation
 ============
 
-This module depends on hr_timesheet_task_stage and hr_timesheet_task_domain
-modules that are in `OCA/timesheet <https://github.com/OCA/timesheet>`_
-repository
+This module depends on modules found in these repositories:
+
+* `OCA/timesheet <https://github.com/OCA/timesheet>`__
+* `OCA/web <https://github.com/OCA/web>`__
 
 Usage
 =====
@@ -49,26 +49,63 @@ You can access via timesheets:
 
 #. Go to *Timesheets > Timesheet > All Timesheets*.
 #. Create a new record.
-#. You will see now that the "Date" field contains also time information.
+#. You will see now that the *Date* field contains also time information.
 #. If you don't select any "project", you will be able to select any "task",
    opened or not.
 #. Selecting a "task", the corresponding "project" is filled.
 #. Selecting a "project", tasks are filtered for only allow
    to select opened tasks for that project. Remember that an opened task is
    a task whose stage doesn't have "Closed" mark checked.
-#. At the end of the line, you will see an stop button.
-#. When you press this button, the difference between "Date" field and the
-   current time, writing this in the field "Duration".
-#. You can modify the "Date" field for altering the computation of the
+#. At the end of the line, you will see a stop button.
+#. When you press this button, the difference between *Date* field and the
+   current time is saved in the "Duration" field.
+#. You can modify the *Date* field for altering the computation of the
    duration.
+#. After a record is stopped, you see a *Resume* button, which will open a
+   wizard that inherits all relevant values from that timesheet line and lets
+   you duplicate it to indicate you start working in the same thing.
+#. If you didn't stop the timer, but still hit *Resume* in any other, the
+   wizard will tell you that you have a running timer and that starting a new
+   one will stop the other one that is running.
+
+To access the wizard directly:
+
+#. Go to *Timesheet > Timesheet > Start work*.
+#. You will be able to enter a new timesheet line from scratch, but by using
+   this wizard, you avoid problems with old or duplicate running timers.
+
+Or via projects:
+
+#. Go to *Project > Projects*.
+#. If a project has a running timesheet line, it will display a *Stop* button.
+#. Other projects that have enabled timesheets will display a *Start* button
+   that will open the same wizard as the timesheet lines, but duplicating
+   project's last timesheet line without a task.
+#. You can see the same in list and form views.
 
 Or via tasks:
 
-#. Go to Project > Search > Tasks.
-#. Click on one existing task or create a new one.
-#. On the "Timesheets" page, you will be able to handle records the same way
+#. Go to *Project > All Tasks*.
+#. If a task has a running timesheet line, it will display a *Stop* button.
+#. Other tasks that have enabled timesheets will display a *Start* button
+   that will open the same wizard as the timesheet lines, duplicating task's
+   last timesheet line.
+#. You can see the same in list view.
+#. Click on any existing task or create a new one.
+#. You can see the same feature in the action buttons box.
+#. On the *Timesheets* page, you will be able to handle records the same way
    as you do in the above explanation (except the task selection part, which
    in this case doesn't appear as it's the current one).
+
+Note: All the *Start/Resume/Stop* features are disabled if you don't belong to
+the *Timesheets/User* group or if you are viewing a timesheet that belongs
+to another user.
+
+Known issues / Roadmap
+======================
+
+* Rename to ``hr_timesheet_time_control``.
+* Move to `OCA/timesheet <https://github.com/OCA/timesheet>`__.
 
 Bug Tracker
 ===========
@@ -99,6 +136,7 @@ Contributors
     * Sergio Teruel
     * Luis M. ontalba
     * Ernesto Tejeda
+    * Jairo Llopis
 
 Maintainers
 ~~~~~~~~~~~

--- a/project_timesheet_time_control/__init__.py
+++ b/project_timesheet_time_control/__init__.py
@@ -1,4 +1,5 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import models
+from . import wizards
 from .hooks import post_init_hook

--- a/project_timesheet_time_control/__manifest__.py
+++ b/project_timesheet_time_control/__manifest__.py
@@ -16,10 +16,14 @@
     'depends': [
         'hr_timesheet_task_stage',
         'hr_timesheet_task_domain',
+        'web_ir_actions_act_multi',
+        'web_ir_actions_act_view_reload',
     ],
     'data': [
         'views/account_analytic_line_view.xml',
+        'views/project_project_view.xml',
         'views/project_task_view.xml',
+        'wizards/hr_timesheet_switch_view.xml',
     ],
     'license': 'AGPL-3',
     'installable': True,

--- a/project_timesheet_time_control/i18n/es.po
+++ b/project_timesheet_time_control/i18n/es.po
@@ -9,34 +9,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-12-22 01:55+0000\n"
-"PO-Revision-Date: 2017-12-22 01:55+0000\n"
-"Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>, 2017\n"
+"POT-Creation-Date: 2019-10-02 09:29+0000\n"
+"PO-Revision-Date: 2019-10-02 10:31+0100\n"
+"Last-Translator: Jairo Llopis <yajo.sk8@gmail.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.2.3\n"
 
 #. module: project_timesheet_time_control
-#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
+#: code:addons/project_timesheet_time_control/wizards/hr_timesheet_switch.py:43
+#, python-format
 msgid ""
-"<i class=\"fa fa-stop-circle\"/>\n"
-"                                            Stop"
+"%d running timers found. Cannot know which one to stop. Please stop them "
+"manually."
 msgstr ""
+"Se han encontrado %d cronómetros en marcha. No hay forma de saber cuál "
+"detener. Por favor, deténgalos manualmente."
 
 #. module: project_timesheet_time_control
-#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_kanban_account_analytic_line
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
 msgid ""
-"<i class=\"fa fa-stop-circle\"/>\n"
-"                                Stop"
+".\n"
+"                        If you continue, it will be stopped with"
 msgstr ""
+".\n"
+"                        Si continúa, se detendrá con"
 
 #. module: project_timesheet_time_control
-#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
-msgid "<strong>Duration: </strong>"
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_project_kanban_inherited
+msgid ""
+"<span class=\"o_label\">\n"
+"                            <i class=\"fa fa-lg fa-play-circle text-success"
+"\"/>\n"
+"                            Start work\n"
+"                        </span>"
 msgstr ""
+"<span class=\"o_label\">\n"
+"                            <i class=\"fa fa-lg fa-play-circle text-success"
+"\"/>\n"
+"                            Comenzar trabajo\n"
+"                        </span>"
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_project_kanban_inherited
+msgid ""
+"<span class=\"o_label\">\n"
+"                            <i class=\"fa fa-lg fa-stop-circle text-warning"
+"\"/>\n"
+"                            Stop work\n"
+"                        </span>"
+msgstr ""
+"<span class=\"o_label\">\n"
+"                            <i class=\"fa fa-lg fa-stop-circle text-warning"
+"\"/>\n"
+"                            Detener trabajo\n"
+"                        </span>"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__amount
+msgid "Amount"
+msgstr "Cantidad"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__account_id
+msgid "Analytic Account"
+msgstr "Cuenta analítica"
 
 #. module: project_timesheet_time_control
 #: model:ir.model,name:project_timesheet_time_control.model_account_analytic_line
@@ -44,6 +85,43 @@ msgid "Analytic Line"
 msgstr "Línea analítica"
 
 #. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Cancel"
+msgstr "Cancelar"
+
+#. module: project_timesheet_time_control
+#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:77
+#, python-format
+msgid "Cannot stop timer %d because it is not running"
+msgstr "No se puede detener el cronómetro %d porque no está en marcha"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__is_task_closed
+msgid "Closed"
+msgstr "Cerrado"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__company_id
+msgid "Company"
+msgstr "Compañía"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__create_uid
+msgid "Created by"
+msgstr "Creado por"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__create_date
+msgid "Created on"
+msgstr "Creado el"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__currency_id
+msgid "Currency"
+msgstr "Moneda"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__date
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.account_analytic_line_tree
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_line_form
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
@@ -52,36 +130,241 @@ msgstr "Fecha"
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_account_analytic_line__date_time
-#, fuzzy
-#| msgid "Date"
-msgid "Date time"
-msgstr "Fecha"
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__date_time
+msgid "Date Time"
+msgstr "Fecha y hora"
 
 #. module: project_timesheet_time_control
-#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_line_form
-#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
-msgid "Duration"
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__department_id
+msgid "Department"
+msgstr "Departmento"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__name
+msgid "Description"
+msgstr "Descripción"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__display_name
+msgid "Display Name"
+msgstr "Nombre mostrado"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__employee_id
+msgid "Employee"
+msgstr "Empleado"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__group_id
+msgid "Group"
+msgstr "Grupo"
+
+#. module: project_timesheet_time_control
+#: model:ir.model,name:project_timesheet_time_control.model_hr_timesheet_switch
+msgid "Helper to quickly switch between timesheet lines"
+msgstr "Ayudante para cambiar rápidamente de línea del parte de horas"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__id
+msgid "ID"
+msgstr "ID"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_account_analytic_line__show_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__show_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_project_project__show_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_project_task__show_time_control
+msgid "Indicate which time control button to show, if any."
 msgstr ""
+"Indica qué botón de control del tiempo mostrar, si es que hay que mostrar "
+"alguno."
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch____last_update
+msgid "Last Modified on"
+msgstr "Última modificación el"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__write_uid
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__write_date
+msgid "Last Updated on"
+msgstr "Última actualización el"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__partner_id
+msgid "Partner"
+msgstr "Contacto"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_id
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Previous timer"
+msgstr "Cronómetro anterior"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_duration
+msgid "Previous timer duration"
+msgstr "Duración del cronómetro anterior"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_start
+msgid "Previous timer start"
+msgstr "Comienzo del cronómetro anterior"
+
+#. module: project_timesheet_time_control
+#: model:ir.model,name:project_timesheet_time_control.model_project_project
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__project_id
+msgid "Project"
+msgstr "Proyecto"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__unit_amount
+msgid "Quantity"
+msgstr "Cantidad"
+
+#. module: project_timesheet_time_control
+#: selection:account.analytic.line,show_time_control:0
+#: selection:hr.timesheet.switch,show_time_control:0
+msgid "Resume"
+msgstr "Continuar"
+
+#. module: project_timesheet_time_control
+#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:62
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.account_analytic_line_tree
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_line_form
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_kanban_account_analytic_line
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
+#, python-format
+msgid "Resume work"
+msgstr "Continuar trabajo"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_account_analytic_line__show_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__show_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_project_project__show_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_project_task__show_time_control
+msgid "Show Time Control"
+msgstr "Mostrar controles del cronómetro"
+
+#. module: project_timesheet_time_control
+#: selection:project.project,show_time_control:0
+#: selection:project.task,show_time_control:0
+msgid "Start"
+msgstr "Comenzar"
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Start new timer"
+msgstr "Comenzar nuevo cronómetro"
+
+#. module: project_timesheet_time_control
+#: code:addons/project_timesheet_time_control/models/project_project.py:48
+#: code:addons/project_timesheet_time_control/models/project_task.py:48
+#: model:ir.actions.act_window,name:project_timesheet_time_control.hr_timesheet_switch_action
+#: model:ir.ui.menu,name:project_timesheet_time_control.hr_timesheet_switch_menu
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.project_invoice_form
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_project_tree
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_kanban
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_tree2_inherited
+#, python-format
+msgid "Start work"
+msgstr "Comenzar trabajo"
+
+#. module: project_timesheet_time_control
+#: selection:account.analytic.line,show_time_control:0
+#: selection:hr.timesheet.switch,show_time_control:0
+#: selection:project.project,show_time_control:0
+#: selection:project.task,show_time_control:0
+msgid "Stop"
+msgstr "Parar"
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Stop previous timer and start the new one"
+msgstr "Detener cronómetro anterior y comenzar el nuevo"
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Stop that very old timer and start the new one"
+msgstr "Detener ese cronómetro tan antiguo y comenzar el nuevo"
 
 #. module: project_timesheet_time_control
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.account_analytic_line_tree
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_line_form
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.project_invoice_form
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_kanban_account_analytic_line
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_project_tree
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
-msgid "Stop"
-msgstr "Parar"
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_kanban
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_tree2_inherited
+msgid "Stop work"
+msgstr "Detener trabajo"
 
-#~ msgid "Close task"
-#~ msgstr "Cerrar tarea"
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__tag_ids
+msgid "Tags"
+msgstr "Etiquetas"
 
-#~ msgid "Closed"
-#~ msgstr "Cerrado"
+#. module: project_timesheet_time_control
+#: model:ir.model,name:project_timesheet_time_control.model_project_task
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__task_id
+msgid "Task"
+msgstr "Tarea"
 
-#~ msgid "Open task"
-#~ msgstr "Abrir tarea"
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__is_task_closed
+msgid "Tasks in this stage are considered closed."
+msgstr "Tareas en esta etapa se considerarán cerradas."
 
-#~ msgid "Tasks in this stage are considered closed."
-#~ msgstr "Tareas en esta etapa se considerarán cerradas."
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "That is a lot of time! Make sure it is fine before saving."
+msgstr ""
+"¡Eso es muchísimo tiempo! Asegúrese de que es correcto antes de guardar."
 
-#~ msgid "There isn't any stage with closed check. Please mark any."
-#~ msgstr ""
-#~ "No hay ninguna etapa con la casilla Cerrado. Por favor marque alguna."
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "The previous timer is old. Do you really want to stop it now?"
+msgstr ""
+"El anterior cronómetro lleva demasiado tiempo en marcha. ¿Seguro que "
+"quieres detenerlo ahora?"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_id
+msgid "This timer is running and will be stopped"
+msgstr "Este cronómetro está en marcha y se detendrá"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__product_uom_id
+msgid "Unit of Measure"
+msgstr "Unidad de medida"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__user_id
+msgid "User"
+msgstr "Usuario"
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_duration
+msgid "When the previous timer is stopped, it will save this duration."
+msgstr "Cuando se detenga el cronómetro anterior, tendrá esta duración."
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "You have a running timer called"
+msgstr "Tiene un cronómetro en marcha llamado"
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "and started at"
+msgstr "que comenzó el"
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "hour(s)."
+msgstr "hora(s)."

--- a/project_timesheet_time_control/i18n/project_timesheet_time_control.pot
+++ b/project_timesheet_time_control/i18n/project_timesheet_time_control.pot
@@ -1,11 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* project_timesheet_time_control
+#       * project_timesheet_time_control
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-10-02 09:29+0000\n"
+"PO-Revision-Date: 2019-10-02 09:29+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,20 +16,41 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: project_timesheet_time_control
-#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
-msgid "<i class=\"fa fa-stop-circle\"/>\n"
-"                                            Stop"
+#: code:addons/project_timesheet_time_control/wizards/hr_timesheet_switch.py:43
+#, python-format
+msgid "%d running timers found. Cannot know which one to stop. Please stop them manually."
 msgstr ""
 
 #. module: project_timesheet_time_control
-#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_kanban_account_analytic_line
-msgid "<i class=\"fa fa-stop-circle\"/>\n"
-"                                Stop"
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid ".\n"
+"                        If you continue, it will be stopped with"
 msgstr ""
 
 #. module: project_timesheet_time_control
-#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
-msgid "<strong>Duration: </strong>"
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_project_kanban_inherited
+msgid "<span class=\"o_label\">\n"
+"                            <i class=\"fa fa-lg fa-play-circle text-success\"/>\n"
+"                            Start work\n"
+"                        </span>"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_project_kanban_inherited
+msgid "<span class=\"o_label\">\n"
+"                            <i class=\"fa fa-lg fa-stop-circle text-warning\"/>\n"
+"                            Stop work\n"
+"                        </span>"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__amount
+msgid "Amount"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__account_id
+msgid "Analytic Account"
 msgstr ""
 
 #. module: project_timesheet_time_control
@@ -36,6 +59,43 @@ msgid "Analytic Line"
 msgstr ""
 
 #. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Cancel"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:77
+#, python-format
+msgid "Cannot stop timer %d because it is not running"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__is_task_closed
+msgid "Closed"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__company_id
+msgid "Company"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__date
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.account_analytic_line_tree
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_line_form
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
@@ -44,19 +104,236 @@ msgstr ""
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_account_analytic_line__date_time
-msgid "Date time"
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__date_time
+msgid "Date Time"
 msgstr ""
 
 #. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__department_id
+msgid "Department"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__name
+msgid "Description"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__employee_id
+msgid "Employee"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__group_id
+msgid "Group"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model,name:project_timesheet_time_control.model_hr_timesheet_switch
+msgid "Helper to quickly switch between timesheet lines"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__id
+msgid "ID"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_account_analytic_line__show_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__show_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_project_project__show_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_project_task__show_time_control
+msgid "Indicate which time control button to show, if any."
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch____last_update
+msgid "Last Modified on"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_id
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Previous timer"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_duration
+msgid "Previous timer duration"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_start
+msgid "Previous timer start"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model,name:project_timesheet_time_control.model_project_project
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__project_id
+msgid "Project"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__unit_amount
+msgid "Quantity"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: selection:account.analytic.line,show_time_control:0
+#: selection:hr.timesheet.switch,show_time_control:0
+msgid "Resume"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:62
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.account_analytic_line_tree
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_line_form
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_kanban_account_analytic_line
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
-msgid "Duration"
+#, python-format
+msgid "Resume work"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_account_analytic_line__show_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__show_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_project_project__show_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_project_task__show_time_control
+msgid "Show Time Control"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: selection:project.project,show_time_control:0
+#: selection:project.task,show_time_control:0
+msgid "Start"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Start new timer"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: code:addons/project_timesheet_time_control/models/project_project.py:48
+#: code:addons/project_timesheet_time_control/models/project_task.py:48
+#: model:ir.actions.act_window,name:project_timesheet_time_control.hr_timesheet_switch_action
+#: model:ir.ui.menu,name:project_timesheet_time_control.hr_timesheet_switch_menu
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.project_invoice_form
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_project_tree
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_kanban
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_tree2_inherited
+#, python-format
+msgid "Start work"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: selection:account.analytic.line,show_time_control:0
+#: selection:hr.timesheet.switch,show_time_control:0
+#: selection:project.project,show_time_control:0
+#: selection:project.task,show_time_control:0
+msgid "Stop"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Stop previous timer and start the new one"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "Stop that very old timer and start the new one"
 msgstr ""
 
 #. module: project_timesheet_time_control
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.account_analytic_line_tree
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_line_form
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.project_invoice_form
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_kanban_account_analytic_line
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_project_tree
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_form2_inherited
-msgid "Stop"
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_kanban
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_task_tree2_inherited
+msgid "Stop work"
 msgstr ""
 
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__tag_ids
+msgid "Tags"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model,name:project_timesheet_time_control.model_project_task
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__task_id
+msgid "Task"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__is_task_closed
+msgid "Tasks in this stage are considered closed."
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "That is a lot of time! Make sure it is fine before saving."
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "The previous timer is old. Do you really want to stop it now?"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_id
+msgid "This timer is running and will be stopped"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__product_uom_id
+msgid "Unit of Measure"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__user_id
+msgid "User"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_duration
+msgid "When the previous timer is stopped, it will save this duration."
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "You have a running timer called"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "and started at"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
+msgid "hour(s)."
+msgstr ""

--- a/project_timesheet_time_control/models/__init__.py
+++ b/project_timesheet_time_control/models/__init__.py
@@ -1,3 +1,5 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import account_analytic_line
+from . import project_project
+from . import project_task

--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -3,33 +3,89 @@
 # Copyright 2016-2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import api, fields, models
 from datetime import datetime
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class AccountAnalyticLine(models.Model):
     _inherit = 'account.analytic.line'
     _order = 'date_time desc'
 
-    date_time = fields.Datetime(default=fields.Datetime.now,
-                                string='Date time')
+    date_time = fields.Datetime(
+        default=fields.Datetime.now,
+        copy=False,
+    )
+    show_time_control = fields.Selection(
+        selection=[("resume", "Resume"), ("stop", "Stop")],
+        compute="_compute_show_time_control",
+        help="Indicate which time control button to show, if any.",
+    )
 
-    def eval_date(self, vals):
+    @api.model
+    def _eval_date(self, vals):
         if vals.get('date_time'):
-            vals['date'] = fields.Date.to_date(vals['date_time'])
+            return dict(vals, date=fields.Date.to_date(vals['date_time']))
         return vals
 
     @api.model
-    def create(self, vals):
-        return super(AccountAnalyticLine, self).create(self.eval_date(vals))
+    def _running_domain(self):
+        """Domain to find running timesheet lines."""
+        return [
+            ("date_time", "!=", False),
+            ("employee_id", "in", self.env.user.employee_ids.ids),
+            ("project_id.allow_timesheets", "=", True),
+            ("unit_amount", "=", 0),
+        ]
+
+    @api.model
+    def _duration(self, start, end):
+        """Compute float duration between start and end."""
+        try:
+            return (end - start).total_seconds() / 3600
+        except TypeError:
+            return 0
+
+    @api.depends("employee_id", "unit_amount")
+    def _compute_show_time_control(self):
+        """Decide when to show time controls."""
+        for one in self:
+            if one.employee_id not in self.env.user.employee_ids:
+                one.show_time_control = False
+            elif one.unit_amount or not one.date_time:
+                one.show_time_control = "resume"
+            else:
+                one.show_time_control = "stop"
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        return super().create(list(map(self._eval_date, vals_list)))
 
     @api.multi
     def write(self, vals):
-        return super(AccountAnalyticLine, self).write(self.eval_date(vals))
+        return super().write(self._eval_date(vals))
+
+    def button_resume_work(self):
+        """Create a new record starting now, with a running timer."""
+        return {
+            "name": _("Resume work"),
+            "res_model": "hr.timesheet.switch",
+            "target": "new",
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "view_type": "form",
+        }
 
     @api.multi
     def button_end_work(self):
-        now = datetime.now()
+        end = fields.Datetime.to_datetime(
+            self.env.context.get("stop_dt", datetime.now()))
         for line in self:
-            line.unit_amount = (now - line.date_time).total_seconds() / 3600
+            if line.unit_amount:
+                raise UserError(
+                    _("Cannot stop timer %d because it is not running. "
+                      "Refresh the page and check again.") %
+                    line.id
+                )
+            line.unit_amount = line._duration(line.date_time, end)
         return True

--- a/project_timesheet_time_control/models/project_project.py
+++ b/project_timesheet_time_control/models/project_project.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+
+
+class ProjectProject(models.Model):
+    _inherit = "project.project"
+
+    show_time_control = fields.Selection(
+        selection=[("start", "Start"), ("stop", "Stop")],
+        compute="_compute_show_time_control",
+        help="Indicate which time control button to show, if any.",
+    )
+
+    @api.model
+    def _timesheet_running_domain(self):
+        """Domain to find running timesheet lines."""
+        return self.env["account.analytic.line"]._running_domain() + [
+            ("project_id", "in", self.ids),
+        ]
+
+    @api.depends("allow_timesheets")
+    def _compute_show_time_control(self):
+        """Decide which time control button to show, if any."""
+        grouped = self.env["account.analytic.line"].read_group(
+            domain=self._timesheet_running_domain(),
+            fields=["id"],
+            groupby=["project_id"],
+        )
+        lines_per_project = {group["project_id"][0]: group["project_id_count"]
+                             for group in grouped}
+        button_per_lines = {0: "start", 1: "stop"}
+        for project in self:
+            if not project.allow_timesheets:
+                project.show_time_control = False
+                continue
+            project.show_time_control = button_per_lines.get(
+                lines_per_project.get(project.id, 0),
+                False,
+            )
+
+    def button_start_work(self):
+        """Create a new record starting now, with a running timer."""
+        return {
+            "context": {
+                "default_project_id": self.id,
+                "default_task_id": False,
+            },
+            "name": _("Start work"),
+            "res_model": "hr.timesheet.switch",
+            "target": "new",
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "view_type": "form",
+        }
+
+    @api.multi
+    def button_end_work(self):
+        running_lines = self.env["account.analytic.line"].search(
+            self._timesheet_running_domain(),
+        )
+        return running_lines.button_end_work()

--- a/project_timesheet_time_control/models/project_task.py
+++ b/project_timesheet_time_control/models/project_task.py
@@ -1,0 +1,63 @@
+# Copyright 2019 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, fields, models
+
+
+class ProjectTask(models.Model):
+    _inherit = "project.task"
+
+    show_time_control = fields.Selection(
+        selection=[("start", "Start"), ("stop", "Stop")],
+        compute="_compute_show_time_control",
+        help="Indicate which time control button to show, if any.",
+    )
+
+    @api.model
+    def _timesheet_running_domain(self):
+        """Domain to find running timesheet lines."""
+        return self.env["account.analytic.line"]._running_domain() + [
+            ("task_id", "in", self.ids),
+        ]
+
+    @api.depends("timesheet_ids.employee_id", "timesheet_ids.unit_amount")
+    def _compute_show_time_control(self):
+        """Decide which time control button to show, if any."""
+        grouped = self.env["account.analytic.line"].read_group(
+            domain=self._timesheet_running_domain(),
+            fields=["id"],
+            groupby=["task_id"],
+        )
+        lines_per_task = {group["task_id"][0]: group["task_id_count"]
+                          for group in grouped}
+        button_per_lines = {0: "start", 1: "stop"}
+        for task in self:
+            if not task.project_id.allow_timesheets:
+                task.show_time_control = False
+                continue
+            task.show_time_control = button_per_lines.get(
+                lines_per_task.get(task.id, 0),
+                False,
+            )
+
+    def button_start_work(self):
+        """Create a new record starting now, with a running timer."""
+        return {
+            "context": {
+                "default_project_id": self.project_id.id,
+                "default_task_id": self.id,
+            },
+            "name": _("Start work"),
+            "res_model": "hr.timesheet.switch",
+            "target": "new",
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "view_type": "form",
+        }
+
+    @api.multi
+    def button_end_work(self):
+        running_lines = self.env["account.analytic.line"].search(
+            self._timesheet_running_domain(),
+        )
+        return running_lines.button_end_work()

--- a/project_timesheet_time_control/readme/CONTRIBUTORS.rst
+++ b/project_timesheet_time_control/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
     * Sergio Teruel
     * Luis M. ontalba
     * Ernesto Tejeda
+    * Jairo Llopis

--- a/project_timesheet_time_control/readme/DESCRIPTION.rst
+++ b/project_timesheet_time_control/readme/DESCRIPTION.rst
@@ -1,4 +1,3 @@
-* This module adds a button at account analytic line level to compute the spent
-  time, in minutes, from start date to the current moment.
-* It adds a datetime field that replaces ``date`` field in tree view, and write
-  date field with datetime field value.
+Allow to track the exact moment when a timesheet line is started (not only
+the day, but also the minute and second) and let users start and stop timers
+easily.

--- a/project_timesheet_time_control/readme/INSTALL.rst
+++ b/project_timesheet_time_control/readme/INSTALL.rst
@@ -1,3 +1,4 @@
-This module depends on hr_timesheet_task_stage and hr_timesheet_task_domain
-modules that are in `OCA/timesheet <https://github.com/OCA/timesheet>`_
-repository
+This module depends on modules found in these repositories:
+
+* `OCA/timesheet <https://github.com/OCA/timesheet>`__
+* `OCA/web <https://github.com/OCA/web>`__

--- a/project_timesheet_time_control/readme/ROADMAP.rst
+++ b/project_timesheet_time_control/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+* Rename to ``hr_timesheet_time_control``.
+* Move to `OCA/timesheet <https://github.com/OCA/timesheet>`__.

--- a/project_timesheet_time_control/readme/USAGE.rst
+++ b/project_timesheet_time_control/readme/USAGE.rst
@@ -2,23 +2,54 @@ You can access via timesheets:
 
 #. Go to *Timesheets > Timesheet > All Timesheets*.
 #. Create a new record.
-#. You will see now that the "Date" field contains also time information.
+#. You will see now that the *Date* field contains also time information.
 #. If you don't select any "project", you will be able to select any "task",
    opened or not.
 #. Selecting a "task", the corresponding "project" is filled.
 #. Selecting a "project", tasks are filtered for only allow
    to select opened tasks for that project. Remember that an opened task is
    a task whose stage doesn't have "Closed" mark checked.
-#. At the end of the line, you will see an stop button.
-#. When you press this button, the difference between "Date" field and the
-   current time, writing this in the field "Duration".
-#. You can modify the "Date" field for altering the computation of the
+#. At the end of the line, you will see a stop button.
+#. When you press this button, the difference between *Date* field and the
+   current time is saved in the "Duration" field.
+#. You can modify the *Date* field for altering the computation of the
    duration.
+#. After a record is stopped, you see a *Resume* button, which will open a
+   wizard that inherits all relevant values from that timesheet line and lets
+   you duplicate it to indicate you start working in the same thing.
+#. If you didn't stop the timer, but still hit *Resume* in any other, the
+   wizard will tell you that you have a running timer and that starting a new
+   one will stop the other one that is running.
+
+To access the wizard directly:
+
+#. Go to *Timesheet > Timesheet > Start work*.
+#. You will be able to enter a new timesheet line from scratch, but by using
+   this wizard, you avoid problems with old or duplicate running timers.
+
+Or via projects:
+
+#. Go to *Project > Projects*.
+#. If a project has a running timesheet line, it will display a *Stop* button.
+#. Other projects that have enabled timesheets will display a *Start* button
+   that will open the same wizard as the timesheet lines, but duplicating
+   project's last timesheet line without a task.
+#. You can see the same in list and form views.
 
 Or via tasks:
 
-#. Go to Project > Search > Tasks.
-#. Click on one existing task or create a new one.
-#. On the "Timesheets" page, you will be able to handle records the same way
+#. Go to *Project > All Tasks*.
+#. If a task has a running timesheet line, it will display a *Stop* button.
+#. Other tasks that have enabled timesheets will display a *Start* button
+   that will open the same wizard as the timesheet lines, duplicating task's
+   last timesheet line.
+#. You can see the same in list view.
+#. Click on any existing task or create a new one.
+#. You can see the same feature in the action buttons box.
+#. On the *Timesheets* page, you will be able to handle records the same way
    as you do in the above explanation (except the task selection part, which
    in this case doesn't appear as it's the current one).
+
+Note: All the *Start/Resume/Stop* features are disabled if you don't belong to
+the *Timesheets/User* group or if you are viewing a timesheet that belongs
+to another user.

--- a/project_timesheet_time_control/static/description/index.html
+++ b/project_timesheet_time_control/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils 0.14: http://docutils.sourceforge.net/" />
 <title>Project timesheet time control</title>
 <style type="text/css">
 
@@ -368,31 +368,31 @@ ul.auto-toc {
 !! changes will be overwritten.                   !!
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external" href="https://odoo-community.org/page/development-status"><img alt="Mature" src="https://img.shields.io/badge/maturity-Mature-brightgreen.png" /></a> <a class="reference external" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external" href="https://github.com/OCA/project/tree/12.0/project_timesheet_time_control"><img alt="OCA/project" src="https://img.shields.io/badge/github-OCA%2Fproject-lightgray.png?logo=github" /></a> <a class="reference external" href="https://translation.odoo-community.org/projects/project-12-0/project-12-0-project_timesheet_time_control"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external" href="https://runbot.odoo-community.org/runbot/140/12.0"><img alt="Try me on Runbot" src="https://img.shields.io/badge/runbot-Try%20me-875A7B.png" /></a></p>
-<ul class="simple">
-<li>This module adds a button at account analytic line level to compute the spent
-time, in minutes, from start date to the current moment.</li>
-<li>It adds a datetime field that replaces <tt class="docutils literal">date</tt> field in tree view, and write
-date field with datetime field value.</li>
-</ul>
+<p>Allow to track the exact moment when a timesheet line is started (not only
+the day, but also the minute and second) and let users start and stop timers
+easily.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#installation" id="id1">Installation</a></li>
 <li><a class="reference internal" href="#usage" id="id2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="id3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="id8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
 <div class="section" id="installation">
 <h1><a class="toc-backref" href="#id1">Installation</a></h1>
-<p>This module depends on hr_timesheet_task_stage and hr_timesheet_task_domain
-modules that are in <a class="reference external" href="https://github.com/OCA/timesheet">OCA/timesheet</a>
-repository</p>
+<p>This module depends on modules found in these repositories:</p>
+<ul class="simple">
+<li><a class="reference external" href="https://github.com/OCA/timesheet">OCA/timesheet</a></li>
+<li><a class="reference external" href="https://github.com/OCA/web">OCA/web</a></li>
+</ul>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#id2">Usage</a></h1>
@@ -400,30 +400,67 @@ repository</p>
 <ol class="arabic simple">
 <li>Go to <em>Timesheets &gt; Timesheet &gt; All Timesheets</em>.</li>
 <li>Create a new record.</li>
-<li>You will see now that the “Date” field contains also time information.</li>
+<li>You will see now that the <em>Date</em> field contains also time information.</li>
 <li>If you don’t select any “project”, you will be able to select any “task”,
 opened or not.</li>
 <li>Selecting a “task”, the corresponding “project” is filled.</li>
 <li>Selecting a “project”, tasks are filtered for only allow
 to select opened tasks for that project. Remember that an opened task is
 a task whose stage doesn’t have “Closed” mark checked.</li>
-<li>At the end of the line, you will see an stop button.</li>
-<li>When you press this button, the difference between “Date” field and the
-current time, writing this in the field “Duration”.</li>
-<li>You can modify the “Date” field for altering the computation of the
+<li>At the end of the line, you will see a stop button.</li>
+<li>When you press this button, the difference between <em>Date</em> field and the
+current time is saved in the “Duration” field.</li>
+<li>You can modify the <em>Date</em> field for altering the computation of the
 duration.</li>
+<li>After a record is stopped, you see a <em>Resume</em> button, which will open a
+wizard that inherits all relevant values from that timesheet line and lets
+you duplicate it to indicate you start working in the same thing.</li>
+<li>If you didn’t stop the timer, but still hit <em>Resume</em> in any other, the
+wizard will tell you that you have a running timer and that starting a new
+one will stop the other one that is running.</li>
+</ol>
+<p>To access the wizard directly:</p>
+<ol class="arabic simple">
+<li>Go to <em>Timesheet &gt; Timesheet &gt; Start work</em>.</li>
+<li>You will be able to enter a new timesheet line from scratch, but by using
+this wizard, you avoid problems with old or duplicate running timers.</li>
+</ol>
+<p>Or via projects:</p>
+<ol class="arabic simple">
+<li>Go to <em>Project &gt; Projects</em>.</li>
+<li>If a project has a running timesheet line, it will display a <em>Stop</em> button.</li>
+<li>Other projects that have enabled timesheets will display a <em>Start</em> button
+that will open the same wizard as the timesheet lines, but duplicating
+project’s last timesheet line without a task.</li>
+<li>You can see the same in list and form views.</li>
 </ol>
 <p>Or via tasks:</p>
 <ol class="arabic simple">
-<li>Go to Project &gt; Search &gt; Tasks.</li>
-<li>Click on one existing task or create a new one.</li>
-<li>On the “Timesheets” page, you will be able to handle records the same way
+<li>Go to <em>Project &gt; All Tasks</em>.</li>
+<li>If a task has a running timesheet line, it will display a <em>Stop</em> button.</li>
+<li>Other tasks that have enabled timesheets will display a <em>Start</em> button
+that will open the same wizard as the timesheet lines, duplicating task’s
+last timesheet line.</li>
+<li>You can see the same in list view.</li>
+<li>Click on any existing task or create a new one.</li>
+<li>You can see the same feature in the action buttons box.</li>
+<li>On the <em>Timesheets</em> page, you will be able to handle records the same way
 as you do in the above explanation (except the task selection part, which
 in this case doesn’t appear as it’s the current one).</li>
 </ol>
+<p>Note: All the <em>Start/Resume/Stop</em> features are disabled if you don’t belong to
+the <em>Timesheets/User</em> group or if you are viewing a timesheet that belongs
+to another user.</p>
+</div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id3">Known issues / Roadmap</a></h1>
+<ul class="simple">
+<li>Rename to <tt class="docutils literal">hr_timesheet_time_control</tt>.</li>
+<li>Move to <a class="reference external" href="https://github.com/OCA/timesheet">OCA/timesheet</a>.</li>
+</ul>
 </div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/project/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -431,15 +468,15 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id4">Credits</a></h1>
+<h1><a class="toc-backref" href="#id5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id5">Authors</a></h2>
+<h2><a class="toc-backref" href="#id6">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id7">Contributors</a></h2>
 <ul>
 <li><p class="first"><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:</p>
 <blockquote>
@@ -450,13 +487,14 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Sergio Teruel</li>
 <li>Luis M. ontalba</li>
 <li>Ernesto Tejeda</li>
+<li>Jairo Llopis</li>
 </ul>
 </blockquote>
 </li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -2,15 +2,28 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0
 
 from odoo.tests import common
-from odoo import fields
+from odoo import exceptions, fields
 from datetime import timedelta, date, datetime
 
 
 class TestProjectTimesheetTimeControl(common.TransactionCase):
     def setUp(self):
-        super(TestProjectTimesheetTimeControl, self).setUp()
-        self.project = self.env['project.project'].create(
-            {'name': 'Test project'})
+        super().setUp()
+        admin = self.browse_ref("base.user_admin")
+        admin.groups_id |= \
+            self.browse_ref("hr_timesheet.group_hr_timesheet_user")
+        self.uid = admin.id
+        self.other_employee = self.env["hr.employee"].create({
+            "name": "Somebody else",
+        })
+        self.project = self.env['project.project'].create({
+            'name': 'Test project',
+            "allow_timesheets": True,
+        })
+        self.project_without_timesheets = self.env['project.project'].create({
+            'name': 'Test project',
+            "allow_timesheets": False,
+        })
         self.analytic_account = self.project.analytic_account_id
         self.task = self.env['project.task'].create({
             'name': 'Test task',
@@ -19,20 +32,213 @@ class TestProjectTimesheetTimeControl(common.TransactionCase):
         self.line = self.env['account.analytic.line'].create({
             'date_time': datetime.now() - timedelta(hours=1),
             'task_id': self.task.id,
+            'project_id': self.project.id,
             'account_id': self.analytic_account.id,
             'name': 'Test line',
         })
 
+    def _create_wizard(self, action, active_record):
+        """Create a new hr.timesheet.switch wizard in the specified context.
+
+        :param dict action: Action definition that creates the wizard.
+        :param active_record: Record being browsed when creating the wizard.
+        """
+        self.assertEqual(action["res_model"], "hr.timesheet.switch")
+        self.assertEqual(action["target"], "new")
+        self.assertEqual(action["type"], "ir.actions.act_window")
+        self.assertEqual(action["view_mode"], "form")
+        self.assertEqual(action["view_type"], "form")
+        return active_record.env[action["res_model"]].with_context(
+            active_id=active_record.id,
+            active_ids=active_record.ids,
+            active_model=active_record._name,
+            **action.get("context", {}),
+        ).create({})
+
+    def test_aal_from_other_employee_no_button(self):
+        """Lines from other employees have no resume/stop button."""
+        self.line.employee_id = self.other_employee
+        self.assertFalse(self.line.show_time_control)
+
     def test_create_write_analytic_line(self):
         line = self.env['account.analytic.line'].create({
             'date_time': fields.Datetime.now(),
-            'account_id': self.analytic_account.id,
+            'project_id': self.project.id,
             'name': 'Test line',
         })
         self.assertEqual(line.date, fields.Date.today())
         line.date_time = '2016-03-23 18:27:00'
         self.assertEqual(line.date, date(2016, 3, 23))
 
-    def test_button_end_work(self):
+    def test_aal_time_control_flow(self):
+        """Test account.analytic.line time controls."""
+        # Duration == 0, stop the timer
+        self.assertFalse(self.line.unit_amount)
+        self.assertEqual(self.line.show_time_control, "stop")
         self.line.button_end_work()
+        # Duration > 0, cannot stop it
         self.assertTrue(self.line.unit_amount)
+        with self.assertRaises(exceptions.UserError):
+            self.line.button_end_work()
+        # Open a new running AAL without wizard
+        running_timer = self.line.copy({
+            "unit_amount": False,
+        })
+        # Use resume wizard
+        self.line.invalidate_cache()
+        self.assertEqual(self.line.show_time_control, "resume")
+        resume_action = self.line.button_resume_work()
+        wizard = self._create_wizard(resume_action, self.line)
+        self.assertFalse(wizard.amount)
+        self.assertLessEqual(wizard.date_time, datetime.now())
+        self.assertLessEqual(wizard.date, date.today())
+        self.assertFalse(wizard.is_task_closed)
+        self.assertFalse(wizard.unit_amount)
+        self.assertEqual(wizard.account_id, self.line.account_id)
+        self.assertEqual(wizard.employee_id, self.line.employee_id)
+        self.assertEqual(wizard.name, self.line.name)
+        self.assertEqual(wizard.project_id, self.line.project_id)
+        self.assertEqual(wizard.running_timer_id, running_timer)
+        self.assertEqual(wizard.task_id, self.line.task_id)
+        # Changing start time changes expected duration
+        wizard.date_time = running_timer.date_time + timedelta(minutes=30)
+        self.assertEqual(wizard.running_timer_duration, 0.5)
+        wizard.date_time = running_timer.date_time + timedelta(hours=2)
+        self.assertEqual(wizard.running_timer_duration, 2)
+        # Stop old timer, start new one
+        new_act = wizard.with_context(show_created_timer=True).action_switch()
+        new_line = self.env[new_act["res_model"]].browse(new_act["res_id"])
+        self.assertEqual(new_line.date_time,
+                         running_timer.date_time + timedelta(hours=2))
+        self.assertEqual(new_line.employee_id, running_timer.employee_id)
+        self.assertEqual(new_line.project_id, running_timer.project_id)
+        self.assertEqual(new_line.task_id, running_timer.task_id)
+        self.assertEqual(new_line.unit_amount, 0)
+        self.assertEqual(running_timer.unit_amount, 2)
+
+    def test_aal_without_start_resume_button(self):
+        """If a line has no start date, can only resume it."""
+        self.assertEqual(self.line.show_time_control, "stop")
+        self.line.date_time = False
+        self.line.invalidate_cache()
+        self.assertEqual(self.line.show_time_control, "resume")
+
+    def test_error_multiple_running_timers(self):
+        """If there are multiple running timers, I don't know which to stop."""
+        self.line.copy({})
+        self.line.copy({})
+        self.line.button_end_work()
+        resume_action = self.line.button_resume_work()
+        with self.assertRaises(exceptions.UserError):
+            self._create_wizard(resume_action, self.line)
+
+    def test_project_time_control_flow(self):
+        """Test project.project time controls."""
+        # Resuming a project will try to find lines without task
+        line_without_task = self.line.copy({
+            "task_id": False,
+            "project_id": self.project.id,
+            "name": "No task here",
+        })
+        self.assertFalse(line_without_task.unit_amount)
+        # Multiple running lines found, no buttons
+        self.assertFalse(self.project.show_time_control)
+        # Stop line without task, now we see stop button
+        line_without_task.button_end_work()
+        self.project.invalidate_cache()
+        self.assertEqual(self.project.show_time_control, "stop")
+        self.project.button_end_work()
+        # All lines stopped, start new one
+        self.project.invalidate_cache()
+        self.assertEqual(self.project.show_time_control, "start")
+        start_action = self.project.button_start_work()
+        wizard = self._create_wizard(start_action, self.project)
+        self.assertFalse(wizard.amount)
+        self.assertLessEqual(wizard.date_time, datetime.now())
+        self.assertLessEqual(wizard.date, date.today())
+        self.assertFalse(wizard.is_task_closed)
+        self.assertFalse(wizard.unit_amount)
+        self.assertEqual(wizard.account_id, self.project.analytic_account_id)
+        self.assertEqual(wizard.employee_id, self.env.user.employee_ids)
+        self.assertEqual(wizard.name, "No task here")
+        self.assertEqual(wizard.project_id, self.project)
+        self.assertFalse(wizard.running_timer_id, self.line)
+        self.assertFalse(wizard.task_id)
+        new_act = wizard.with_context(show_created_timer=True).action_switch()
+        new_line = self.env[new_act["res_model"]].browse(new_act["res_id"])
+        self.assertEqual(new_line.employee_id, self.env.user.employee_ids)
+        self.assertEqual(new_line.project_id, self.project)
+        self.assertFalse(new_line.task_id)
+        self.assertEqual(new_line.unit_amount, 0)
+        self.assertTrue(self.line.unit_amount)
+        # Projects without timesheets show no buttons
+        self.assertFalse(self.project_without_timesheets.show_time_control)
+
+    def test_task_time_control_flow(self):
+        """Test project.task time controls."""
+        # Running line found, stop the timer
+        self.assertEqual(self.task.show_time_control, "stop")
+        self.task.button_end_work()
+        # All lines stopped, start new one
+        self.task.invalidate_cache()
+        self.assertEqual(self.task.show_time_control, "start")
+        start_action = self.task.button_start_work()
+        wizard = self._create_wizard(start_action, self.task)
+        self.assertFalse(wizard.amount)
+        self.assertLessEqual(wizard.date_time, datetime.now())
+        self.assertLessEqual(wizard.date, date.today())
+        self.assertFalse(wizard.is_task_closed)
+        self.assertFalse(wizard.unit_amount)
+        self.assertEqual(
+            wizard.account_id,
+            self.task.project_id.analytic_account_id)
+        self.assertEqual(wizard.employee_id, self.env.user.employee_ids)
+        self.assertEqual(wizard.name, self.line.name)
+        self.assertEqual(wizard.project_id, self.task.project_id)
+        self.assertEqual(wizard.task_id, self.task)
+        new_act = wizard.with_context(show_created_timer=True).action_switch()
+        new_line = self.env[new_act["res_model"]].browse(new_act["res_id"])
+        self.assertEqual(new_line.employee_id, self.env.user.employee_ids)
+        self.assertEqual(new_line.project_id, self.project)
+        self.assertEqual(new_line.task_id, self.task)
+        self.assertEqual(new_line.unit_amount, 0)
+        self.assertTrue(self.line.unit_amount)
+
+    def test_wizard_standalone(self):
+        """Standalone wizard usage works properly."""
+        # It detects the running timer
+        wizard = self.env["hr.timesheet.switch"].create({
+            "name": "Standalone 1",
+            "project_id": self.project.id,
+        })
+        self.assertEqual(wizard.running_timer_id, self.line)
+        self.assertTrue(wizard.running_timer_duration)
+        new_act = wizard.with_context(show_created_timer=True).action_switch()
+        new_line = self.env[new_act["res_model"]].browse(new_act["res_id"])
+        self.assertEqual(new_line.name, "Standalone 1")
+        self.assertEqual(new_line.project_id, self.project)
+        # It also works if there is no running timer
+        new_line.button_end_work()
+        wizard = self.env["hr.timesheet.switch"] \
+            .with_context(active_model="unknown", active_id=1) \
+            .create({
+                "name": "Standalone 2",
+                "project_id": self.project.id,
+            })
+        self.assertFalse(wizard.running_timer_id)
+        self.assertFalse(wizard.running_timer_duration)
+        new_act = wizard.action_switch()
+        self.assertEqual(new_act, {
+            "type": "ir.actions.act_multi",
+            "actions": [
+                {"type": "ir.actions.act_window_close"},
+                {"type": "ir.actions.act_view_reload"},
+            ],
+        })
+        new_line = self.env["account.analytic.line"].search([
+            ("name", "=", "Standalone 2"),
+            ("project_id", "=", self.project.id),
+            ("unit_amount", "=", 0),
+            ("employee_id", "=", self.line.employee_id.id),
+        ])
+        self.assertEqual(len(new_line), 1)

--- a/project_timesheet_time_control/views/account_analytic_line_view.xml
+++ b/project_timesheet_time_control/views/account_analytic_line_view.xml
@@ -9,14 +9,25 @@
                 <attribute name="invisible">1</attribute>
             </field>
             <field name="date" position="after">
-                <field name="date_time" string="Date"/>
+                <field name="date_time" string="Date" required="1"/>
             </field>
             <field name="unit_amount" position="after">
-                <button name="button_end_work"
-                        string="Stop"
+                <field name="show_time_control" invisible="1"/>
+                <button name="button_resume_work"
+                        string="Resume work"
+                        tabindex="-1"
                         type="object"
-                        icon="fa-stop-circle"
-                        attrs="{'invisible': [('unit_amount', '>', 0)]}"
+                        icon="fa-play-circle text-success"
+                        attrs="{'invisible': [('show_time_control', '!=', 'resume')]}"
+                        class="oe_stat_button"
+                />
+                <button name="button_end_work"
+                        string="Stop work"
+                        tabindex="-1"
+                        type="object"
+                        icon="fa-stop-circle text-warning"
+                        attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                        class="oe_stat_button"
                 />
             </field>
         </field>
@@ -25,26 +36,31 @@
     <record id="hr_timesheet_line_form" model="ir.ui.view">
         <field name="name">account.analytic.line.form.inherit</field>
         <field name="model">account.analytic.line</field>
-        <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_form"/>
+        <field name="inherit_id" ref="hr_timesheet_task_stage.account_analytic_line_form"/>
         <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <field name="show_time_control" invisible="1"/>
+                <button name="button_resume_work"
+                        string="Resume work"
+                        type="object"
+                        icon="fa-play-circle text-success"
+                        attrs="{'invisible': [('show_time_control', '!=', 'resume')]}"
+                        class="oe_stat_button"
+                        context="{'show_created_timer': True}"
+                />
+                <button name="button_end_work"
+                        string="Stop work"
+                        type="object"
+                        icon="fa-stop-circle text-warning"
+                        attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                        class="oe_stat_button"
+                />
+            </div>
             <field name="date" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
             <field name="date" position="after">
-                <field name="date_time" string="Date"/>
-            </field>
-            <field name="unit_amount" position="replace">
-                <label for="unit_amount"/>
-                <div>
-                    <field name="unit_amount" class="oe_inline" string="Duration" widget="float_time"/>
-                    <button name="button_end_work"
-                            string="Stop"
-                            type="object"
-                            icon="fa-stop-circle"
-                            attrs="{'invisible': [('unit_amount', '>', 0)]}"
-                            class="btn btn-link"
-                    />
-                </div>
+                <field name="date_time" string="Date" required="1"/>
             </field>
         </field>
     </record>
@@ -55,21 +71,23 @@
             <field name="inherit_id"
                    ref="hr_timesheet.view_kanban_account_analytic_line"/>
             <field name="arch" type="xml">
-                <xpath expr="//templates//field[@name='unit_amount']/.." position="after">
-                    <div class="row">
-                        <div class="col-12">
-                            <button name="button_end_work"
-                                    type="object"
-                                    attrs="{'invisible': [('unit_amount', '>', 0)]}"
-                                    class="btn btn-primary float-right btn-sm">
-                                <i class="fa fa-stop-circle"/>
-                                Stop
-                            </button>
-                        </div>
-                    </div>
+                <xpath expr="//templates//field[@name='unit_amount']" position="after">
+                    <field name="show_time_control" invisible="1"/>
+                    <a name="button_resume_work"
+                            string="Resume work"
+                            tabindex="-1"
+                            type="object"
+                            attrs="{'invisible': [('show_time_control', '!=', 'resume')]}"
+                            class="o_kanban_inline_block fa fa-lg fa-play-circle text-success"/>
+                    <a name="button_end_work"
+                            string="Stop work"
+                            tabindex="-1"
+                            type="object"
+                            attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                            class="o_kanban_inline_block fa fa-lg fa-stop-circle text-warning"/>
                 </xpath>
                 <field name="date" position="after">
-                    <field name="date_time"/>
+                    <field name="date_time" required="1"/>
                 </field>
                 <xpath expr="//templates//t[@t-esc='record.date.value']" position="attributes">
                     <attribute name="invisible">1</attribute>

--- a/project_timesheet_time_control/views/project_project_view.xml
+++ b/project_timesheet_time_control/views/project_project_view.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="project_invoice_form" model="ir.ui.view">
+        <field name="name">Add timesheet time controls</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="hr_timesheet.project_invoice_form"/>
+        <field name="groups_id" eval="[(6, 0, [ref('hr_timesheet.group_hr_timesheet_user')])]"/>
+        <field name="arch" type="xml">
+            <div name="button_box" position="inside">
+                <field name="show_time_control" invisible="1"/>
+                <button name="button_start_work"
+                        string="Start work"
+                        type="object"
+                        icon="fa-play-circle text-success"
+                        attrs="{'invisible': [('show_time_control', '!=', 'start')]}"
+                        class="oe_stat_button"
+                />
+                <button name="button_end_work"
+                        string="Stop work"
+                        type="object"
+                        icon="fa-stop-circle text-warning"
+                        attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                        class="oe_stat_button"
+                />
+            </div>
+        </field>
+    </record>
+
+    <record id="view_project_kanban_inherited" model="ir.ui.view">
+        <field name="name">Add timesheet time controls</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="hr_timesheet.view_project_kanban_inherited"/>
+        <field name="groups_id" eval="[(6, 0, [ref('hr_timesheet.group_hr_timesheet_user')])]"/>
+        <field name="arch" type="xml">
+            <xpath expr="//*[hasclass('o_project_kanban_boxes')]" position="inside">
+                <field name="show_time_control" invisible="1"/>
+                <a name="button_start_work"
+                   tabindex="-1"
+                   type="object"
+                   attrs="{'invisible': [('show_time_control', '!=', 'start')]}"
+                   class="o_project_kanban_box">
+                    <div>
+                        <span class="o_label">
+                            <i class="fa fa-lg fa-play-circle text-success"/>
+                            Start work
+                        </span>
+                    </div>
+                </a>
+                <a name="button_end_work"
+                   tabindex="-1"
+                   type="object"
+                   attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                   class="o_project_kanban_box">
+                    <div>
+                        <span class="o_label">
+                            <i class="fa fa-lg fa-stop-circle text-warning"/>
+                            Stop work
+                        </span>
+                    </div>
+                </a>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_project_tree" model="ir.ui.view">
+        <field name="name">Add timesheet time controls</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.view_project"/>
+        <field name="groups_id" eval="[(6, 0, [ref('hr_timesheet.group_hr_timesheet_user')])]"/>
+        <field name="arch" type="xml">
+            <tree position="inside">
+                <field name="show_time_control" invisible="1"/>
+                <button name="button_start_work"
+                        string="Start work"
+                        tabindex="-1"
+                        type="object"
+                        icon="fa-play-circle text-success"
+                        attrs="{'invisible': [('show_time_control', '!=', 'start')]}"
+                        class="oe_stat_button"
+                />
+                <button name="button_end_work"
+                        string="Stop work"
+                        tabindex="-1"
+                        type="object"
+                        icon="fa-stop-circle text-warning"
+                        attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                        class="oe_stat_button"
+                />
+            </tree>
+        </field>
+    </record>
+
+</odoo>

--- a/project_timesheet_time_control/views/project_task_view.xml
+++ b/project_timesheet_time_control/views/project_task_view.xml
@@ -2,100 +2,164 @@
 <odoo>
 
     <record id="view_task_form2_inherited" model="ir.ui.view">
+        <field name="name">Add timesheet time controls</field>
         <field name="model">project.task</field>
         <field name="inherit_id" ref="hr_timesheet.view_task_form2_inherited"/>
+        <field name="groups_id" eval="[(6, 0, [ref('hr_timesheet.group_hr_timesheet_user')])]"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='timesheet_ids']//field[@name='date']" position="attributes">
+            <!-- Main task form action buttons -->
+            <div name="button_box" position="inside">
+                <field name="show_time_control" invisible="1"/>
+                <button name="button_start_work"
+                        string="Start work"
+                        type="object"
+                        icon="fa-play-circle text-success"
+                        attrs="{'invisible': [('show_time_control', '!=', 'start')]}"
+                        class="oe_stat_button"
+                />
+                <button name="button_end_work"
+                        string="Stop work"
+                        type="object"
+                        icon="fa-stop-circle text-warning"
+                        attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                        class="oe_stat_button"
+                />
+            </div>
+
+            <!-- Sub-tree view for timesheet_ids -->
+            <xpath expr="//field[@name='timesheet_ids']/tree//field[@name='date']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
-            <xpath expr="//field[@name='timesheet_ids']//field[@name='date']" position="after">
-                <field name="date_time" string="Date"/>
+            <xpath expr="//field[@name='timesheet_ids']/tree//field[@name='date']" position="after">
+                <field name="date_time" string="Date" required="1"/>
             </xpath>
-            <xpath expr="//field[@name='timesheet_ids']//field[@name='unit_amount']" position="after">
-                <button name="button_end_work"
-                        string="Stop"
+            <xpath expr="//field[@name='timesheet_ids']/tree" position="inside">
+                <field name="show_time_control" invisible="1"/>
+                <button name="button_resume_work"
+                        string="Resume work"
+                        tabindex="-1"
                         type="object"
-                        icon="fa-stop-circle"
-                        attrs="{'invisible': [('unit_amount', '>', 0)]}"
+                        icon="fa-play-circle text-success"
+                        attrs="{'invisible': [('show_time_control', '!=', 'resume')]}"
+                        class="oe_stat_button"
                 />
-            </xpath>
-            <xpath expr="//field[@name='timesheet_ids']" position="attributes">
-                <attribute name="mode">tree,kanban</attribute>
-            </xpath>
-            <xpath expr="//field[@name='timesheet_ids']">
-                <kanban class="o_kanban_mobile">
-                    <field name="date_time"/>
-                    <field name="user_id"/>
-                    <field name="name"/>
-                    <field name="project_id"/>
-                    <field name="task_id" context="{'default_project_id': project_id}" domain="[('project_id', '=', project_id)]"/>
-                    <field name="unit_amount"/>
-                    <templates>
-                        <t t-name="kanban-box">
-                            <div t-attf-class="oe_kanban_global_click">
-                                <a t-if="!read_only_mode" type="delete"
-                                   class="fa fa-times pull-right"/>
-                                <div class="row">
-                                    <div class="col-xs-2">
-                                        <img t-att-src="kanban_image('res.users', 'image_small', record.user_id.raw_value)" t-att-title="record.user_id.value" width="40" height="40" class="oe_kanban_avatar pull-left"/>
-                                    </div>
-                                    <div class="col-xs-10">
-                                        <div>
-                                            <strong><t t-esc="record.name.value"/></strong>
-                                        </div>
-                                    </div>
-                                </div>
-                                <hr class="mt4 mb4"/>
-                                <span>
-                                    <i class="fa fa-calendar" aria-hidden="true"></i>
-                                    <t t-esc="record.date_time.value"/>
-                                </span>
-                                <span class="pull-right">
-                                    <strong>Duration: </strong><field name="unit_amount" widget="float_time"/>
-                                </span>
-                                <div class="row">
-                                    <div class="col-12">
-                                        <button name="button_end_work"
-                                                type="object"
-                                                attrs="{'invisible': [('unit_amount', '>', 0)]}"
-                                                class="btn btn-primary float-right btn-sm">
-                                            <i class="fa fa-stop-circle"/>
-                                            Stop
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
-                        </t>
-                    </templates>
-                </kanban>
-                <form>
-                    <group>
-                        <group>
-                            <field name="date_time" string="Date"/>
-                            <field name="name"/>
-                            <field name="user_id" invisible="1"/>
-                            <field name="employee_id" required="1"/>
-                            <field name="project_id" invisible="1"/>
-                        </group>
-                        <group>
-                            <label for="unit_amount"/>
-                            <div>
-                                <field name="unit_amount" class="oe_inline" string="Duration" widget="float_time"/>
-                                <button name="button_end_work"
-                                        string="Stop"
-                                        type="object"
-                                        icon="fa-stop-circle"
-                                        attrs="{'invisible': [('unit_amount', '>', 0)]}"
-                                        class="btn btn-link"
-                                />
-                            </div>
-                        </group>
-                    </group>
-                </form>
+                <button name="button_end_work"
+                        string="Stop work"
+                        tabindex="-1"
+                        type="object"
+                        icon="fa-stop-circle text-warning"
+                        attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                        class="oe_stat_button"
+                />
             </xpath>
             <xpath expr="//field[@name='timesheet_ids']/tree" position="attributes">
                 <attribute name="default_order">date_time</attribute>
             </xpath>
+
+            <!-- Sub-kanban view for timesheet_ids -->
+            <xpath expr="//field[@name='timesheet_ids']/kanban//*[@t-esc='record.date.value']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='timesheet_ids']/kanban//*[@t-esc='record.date.value']" position="after">
+                <field name="date_time" required="1"/>
+            </xpath>
+            <xpath expr="//field[@name='timesheet_ids']/kanban//templates//field[@name='unit_amount']" position="after">
+                <field name="show_time_control" invisible="1"/>
+                <a name="button_resume_work"
+                   tabindex="-1"
+                   type="object"
+                   string="Resume work"
+                   attrs="{'invisible': [('show_time_control', '!=', 'resume')]}"
+                   class="o_kanban_inline_block fa fa-lg fa-play-circle text-success"/>
+                <a name="button_end_work"
+                   tabindex="-1"
+                   type="object"
+                   string="Stop work"
+                   attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                   class="o_kanban_inline_block fa fa-lg fa-stop-circle text-warning"/>
+            </xpath>
+
+            <!-- Sub-form view for timesheet_ids -->
+            <xpath expr="//field[@name='timesheet_ids']/form//field[@name='date']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='timesheet_ids']/form//field[@name='date']" position="after">
+                <field name="date_time" required="1"/>
+            </xpath>
+            <xpath expr="//field[@name='timesheet_ids']/form/sheet/*" position="before">
+                <div class="oe_button_box" name="button_box">
+                    <field name="show_time_control" invisible="1"/>
+                    <button name="button_resume_work"
+                            string="Resume work"
+                            tabindex="-1"
+                            type="object"
+                            icon="fa-play-circle text-success"
+                            attrs="{'invisible': [('show_time_control', '!=', 'resume')]}"
+                            class="oe_stat_button"
+                            context="{'show_created_timer': True}"
+                    />
+                    <button name="button_end_work"
+                            string="Stop work"
+                            tabindex="-1"
+                            type="object"
+                            icon="fa-stop-circle text-warning"
+                            attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                            class="oe_stat_button"
+                    />
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_task_kanban" model="ir.ui.view">
+        <field name="name">Add timesheet time controls</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_kanban"/>
+        <field name="groups_id" eval="[(6, 0, [ref('hr_timesheet.group_hr_timesheet_user')])]"/>
+        <field name="arch" type="xml">
+            <xpath expr="//*[hasclass('oe_kanban_bottom_left')]" position="inside">
+                <field name="show_time_control" invisible="1"/>
+                <a name="button_start_work"
+                   attrs="{'invisible': [('show_time_control', '!=', 'start')]}"
+                   class="o_kanban_inline_block fa fa-lg fa-play-circle text-success"
+                   string="Start work"
+                   tabindex="-1"
+                   type="object"/>
+                <a name="button_end_work"
+                   attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                   class="o_kanban_inline_block fa fa-lg fa-stop-circle text-warning"
+                   string="Stop work"
+                   tabindex="-1"
+                   type="object"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_task_tree2_inherited" model="ir.ui.view">
+        <field name="name">Add timesheet time controls</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="hr_timesheet.view_task_tree2_inherited"/>
+        <field name="groups_id" eval="[(6, 0, [ref('hr_timesheet.group_hr_timesheet_user')])]"/>
+        <field name="arch" type="xml">
+            <tree position="inside">
+                <field name="show_time_control" invisible="1"/>
+                <button name="button_start_work"
+                        string="Start work"
+                        tabindex="-1"
+                        type="object"
+                        icon="fa-play-circle text-success"
+                        attrs="{'invisible': [('show_time_control', '!=', 'start')]}"
+                        class="oe_stat_button"
+                />
+                <button name="button_end_work"
+                        string="Stop work"
+                        tabindex="-1"
+                        type="object"
+                        icon="fa-stop-circle text-warning"
+                        attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
+                        class="oe_stat_button"
+                />
+            </tree>
         </field>
     </record>
 

--- a/project_timesheet_time_control/wizards/__init__.py
+++ b/project_timesheet_time_control/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_timesheet_switch

--- a/project_timesheet_time_control/wizards/hr_timesheet_switch.py
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch.py
@@ -1,0 +1,153 @@
+# Copyright 2019 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, models, fields
+from odoo.exceptions import UserError
+
+
+class HrTimesheetSwitch(models.TransientModel):
+    _name = "hr.timesheet.switch"
+    _inherit = "account.analytic.line"
+    _description = "Helper to quickly switch between timesheet lines"
+
+    running_timer_id = fields.Many2one(
+        comodel_name="account.analytic.line",
+        string="Previous timer",
+        ondelete="cascade",
+        readonly=True,
+        default=lambda self: self._default_running_timer_id(),
+        help="This timer is running and will be stopped",
+    )
+    running_timer_start = fields.Datetime(
+        string="Previous timer start",
+        related="running_timer_id.date_time",
+        readonly=True,
+    )
+    running_timer_duration = fields.Float(
+        string="Previous timer duration",
+        compute="_compute_running_timer_duration",
+        help="When the previous timer is stopped, it will save this duration.",
+    )
+
+    @api.model
+    def _default_running_timer_id(self, employee=None):
+        """Obtain running timer."""
+        employee = employee or self.env.user.employee_ids
+        # Find running work
+        running = self.env["account.analytic.line"].search([
+            ("date_time", "!=", False),
+            ("employee_id", "in", employee.ids),
+            ("id", "not in", self.env.context.get("resuming_lines", [])),
+            ("project_id", "!=", False),
+            ("unit_amount", "=", 0),
+        ])
+        if len(running) > 1:
+            raise UserError(_(
+                "%d running timers found. Cannot know which one to stop. "
+                "Please stop them manually.") % len(running))
+        return running
+
+    @api.depends("date_time", "running_timer_id")
+    def _compute_running_timer_duration(self):
+        """Compute duration of running timer when stopped."""
+        for one in self:
+            one.running_timer_duration = one._duration(
+                one.running_timer_id.date_time,
+                one.date_time,
+            )
+
+    @api.model
+    def _closest_suggestion(self):
+        """Find most similar account.analytic.line record."""
+        try:
+            active = self.env[self.env.context["active_model"]].browse(
+                self.env.context["active_id"])
+        except KeyError:
+            # If I don't know where's the user, I don't know what to suggest
+            return self.env["account.analytic.line"].browse()
+        # If you're browsing another account.analytic.line, that's the match
+        if active._name == "account.analytic.line":
+            return active
+        # If browsing other models, prepare a search
+        domain = [("employee_id", "in", self.env.user.employee_ids.ids)]
+        if active._name == "project.task":
+            domain.append(("task_id", "=", active.id))
+        elif active._name == "project.project":
+            domain += [
+                ("project_id", "=", active.id),
+                ("task_id", "=", False),
+            ]
+        else:
+            # No clues for other records, sorry
+            return self.env["account.analytic.line"].browse()
+        return self.env["account.analytic.line"].search(
+            domain,
+            order="date_time DESC",
+            limit=1,
+        )
+
+    @api.model
+    def default_get(self, fields_list):
+        """Return defaults depending on the context where it is called."""
+        result = super().default_get(fields_list)
+        inherited = self._closest_suggestion()
+        assert inherited._name == "account.analytic.line"
+        # Inherit all possible fields from that account.analytic.line record
+        if inherited:
+            # Convert inherited to RPC-style values
+            _fields = set(fields_list) & set(inherited._fields) - {
+                # These fields must always be reset
+                "amount",
+                "date_time",
+                "date",
+                "is_task_closed",
+                "unit_amount",
+                # This field is from sale_timesheet, which is not among
+                # this module dependencies; ignoring it will let you
+                # resume an invoiced AAL if that module is installed,
+                # and it doesn't hurt here
+                "timesheet_invoice_id",
+            }
+            inherited.read(_fields)
+            values = inherited._convert_to_write(inherited._cache)
+            for field in _fields:
+                result[field] = values[field]
+        return result
+
+    def action_switch(self):
+        """Stop old timer, start new one."""
+        self.ensure_one()
+        # Stop old timer
+        self.with_context(
+            resuming_lines=self.ids,
+            stop_dt=self.date_time,
+        ).running_timer_id.button_end_work()
+        # Start new timer
+        _fields = self.env["account.analytic.line"]._fields.keys()
+        self.read(_fields)
+        values = self._convert_to_write(self._cache)
+        new = self.env["account.analytic.line"].create({
+            field: value for (field, value) in values.items()
+            if field in _fields
+        })
+        # Display created timer record if requested
+        if self.env.context.get("show_created_timer"):
+            form_view = self.env.ref("hr_timesheet.hr_timesheet_line_form")
+            return {
+                "res_id": new.id,
+                "res_model": new._name,
+                "type": "ir.actions.act_window",
+                "view_mode": "form",
+                "view_type": "form",
+                "views": [
+                    (form_view.id, "form"),
+                ],
+            }
+        # Close wizard and reload view
+        return {
+            "type": "ir.actions.act_multi",
+            "actions": [
+                {"type": "ir.actions.act_window_close"},
+                {"type": "ir.actions.act_view_reload"},
+            ],
+        }

--- a/project_timesheet_time_control/wizards/hr_timesheet_switch_view.xml
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch_view.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2019 Tecnativa - Jairo Llopis
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+
+<data>
+
+    <!-- Wizard view to resume work -->
+    <record id="hr_timesheet_switch_form" model="ir.ui.view">
+        <field name="name">hr.timesheet.switch resume form</field>
+        <field name="model">hr.timesheet.switch</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="hr_timesheet_line_form"/>
+        <field name="arch" type="xml">
+            <!-- Unclutter form -->
+            <div name="button_box" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </div>
+            <field name="amount" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <field name="unit_amount" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+            <xpath expr="//sheet/group/group" position="attributes">
+                <attribute name="colspan">4</attribute>
+            </xpath>
+            <!-- Display messages -->
+            <xpath expr="//sheet/group" position="after">
+                <group name="messages" string="Previous timer" attrs="{'invisible': [('running_timer_id', '=', False)]}">
+                    <p>
+                        You have a running timer called
+                        <field name="running_timer_id" class="oe_inline" context="{'form_view_ref': 'hr_timesheet.hr_timesheet_line_form'}"/>
+                        and started at
+                        <field name="running_timer_start" class="oe_inline"/>.
+                        If you continue, it will be stopped with
+                        <strong>
+                            <field name="running_timer_duration" class="text-info" widget="float_time" attrs="{'invisible': [('running_timer_duration', '&gt;=', 5)]}"/>
+                            <field name="running_timer_duration" class="text-warning" widget="float_time" attrs="{'invisible': [('running_timer_duration', '&lt;', 5)]}"/>
+                            hour(s).
+                        </strong>
+                    </p>
+                    <div class="alert alert-warning" colspan="4" role="alert" attrs="{'invisible': [('running_timer_duration', '&lt;', 5)]}">
+                        That is a lot of time! Make sure it is fine before saving.
+                    </div>
+                </group>
+            </xpath>
+            <!-- Footer buttons -->
+            <sheet position="after">
+                <footer>
+                    <button name="action_switch"
+                            type="object"
+                            attrs="{'invisible': [('running_timer_id', '!=', False)]}"
+                            string="Start new timer"
+                            class="oe_highlight"/>
+                    <button name="action_switch"
+                            type="object"
+                            attrs="{'invisible': ['|', ('running_timer_id', '=', False), ('running_timer_duration', '&gt;=', 5)]}"
+                            string="Stop previous timer and start the new one"
+                            class="oe_highlight"/>
+                    <button name="action_switch"
+                            confirm="The previous timer is old. Do you really want to stop it now?"
+                            type="object"
+                            attrs="{'invisible': ['|', ('running_timer_id', '=', False), ('running_timer_duration', '&lt;', 5)]}"
+                            string="Stop that very old timer and start the new one"
+                            class="btn-warning"/>
+                    <button special="cancel" string="Cancel"/>
+                </footer>
+            </sheet>
+        </field>
+    </record>
+
+    <record id="hr_timesheet_switch_action" model="ir.actions.act_window">
+        <field name="name">Start work</field>
+        <field name="res_model">hr.timesheet.switch</field>
+        <field name="target">new</field>
+        <field name="view_mode">form</field>
+        <field name="view_type">form</field>
+        <field name="context">{'show_created_timer': True}</field>
+    </record>
+
+    <menuitem
+        id="hr_timesheet_switch_menu"
+        name="Start work"
+        action="hr_timesheet_switch_action"
+        parent="hr_timesheet.menu_hr_time_tracking"
+        groups="hr_timesheet.group_hr_timesheet_user"
+        sequence="10"/>
+
+</data>


### PR DESCRIPTION
This is a huge improvement in this module's usability, although basic functionality stays the same. Let me summmarize:

- In `account.analytic.line` views, the *Stop* button is replaced by colorful *Resume/Stop* buttons.
- The new *Resume* button will display a wizard that will duplicate all meaningful fields from the previous `account.analytic.line` record and auto-stop the previous running timer, if any.
- If the previous running timer is very old, some warnings will be displayed.
- In `project.project` and `project.task` views, I added the same buttons (well... it's *Start* instead of *Resume*, because you could not have worked before in that project or task, but it behaves the same).
- If using it from a `project.task`, *Start* will duplicate meaningful fields from your latest line in that task.
- If using it from a `project.project`, *Start* will duplicate meaningful fields your latest line in that project that had no task associated.
- All kanban, kanban mobile, list and form views are covered.
- I removed, BTW, some Bootstrap 3 and bad replacements in some views.

---

@Tecnativa TT19205
Inspired by https://github.com/OCA/timesheet/pull/139.