### PR TITLE
[IMP]  project_timesheet_time_control: Tell the user no running line was found

### DIFF
--- a/project_timesheet_time_control/i18n/es.po
+++ b/project_timesheet_time_control/i18n/es.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-02 09:29+0000\n"
-"PO-Revision-Date: 2019-10-02 10:31+0100\n"
+"POT-Creation-Date: 2019-10-15 09:35+0000\n"
+"PO-Revision-Date: 2019-10-15 10:55+0100\n"
 "Last-Translator: Jairo Llopis <yajo.sk8@gmail.com>\n"
 "Language-Team: Spanish (https://www.transifex.com/oca/teams/23907/es/)\n"
 "Language: es\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.2.3\n"
+"X-Generator: Poedit 2.2.4\n"
 
 #. module: project_timesheet_time_control
 #: code:addons/project_timesheet_time_control/wizards/hr_timesheet_switch.py:45
@@ -90,23 +90,19 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 #. module: project_timesheet_time_control
-#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:86
-#, fuzzy, python-format
-#| msgid "Cannot stop timer %d because it is not running"
+#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:76
+#, python-format
 msgid ""
 "Cannot stop timer %d because it is not running. Refresh the page and check "
 "again."
-msgstr "No se puede detener el cronómetro %d porque no está en marcha"
+msgstr ""
+"No se puede detener el cronómetro %d porque no está en marcha. Refresque la "
+"página y pruebe de nuevo."
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__is_task_closed
 msgid "Closed"
 msgstr "Cerrado"
-
-#. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__code
-msgid "Code"
-msgstr ""
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__company_id
@@ -154,6 +150,7 @@ msgstr "Descripción"
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__display_name
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_time_control_mixin__display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
 
@@ -161,13 +158,6 @@ msgstr "Nombre mostrado"
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__employee_id
 msgid "Employee"
 msgstr "Empleado"
-
-#. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__general_account_id
-#, fuzzy
-#| msgid "Analytic Account"
-msgid "Financial Account"
-msgstr "Cuenta analítica"
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__group_id
@@ -181,12 +171,14 @@ msgstr "Ayudante para cambiar rápidamente de línea del parte de horas"
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__id
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_time_control_mixin__id
 msgid "ID"
 msgstr "ID"
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,help:project_timesheet_time_control.field_account_analytic_line__show_time_control
 #: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__show_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_time_control_mixin__show_time_control
 #: model:ir.model.fields,help:project_timesheet_time_control.field_project_project__show_time_control
 #: model:ir.model.fields,help:project_timesheet_time_control.field_project_task__show_time_control
 msgid "Indicate which time control button to show, if any."
@@ -195,12 +187,8 @@ msgstr ""
 "alguno."
 
 #. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__move_id
-msgid "Journal Item"
-msgstr ""
-
-#. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch____last_update
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_time_control_mixin____last_update
 msgid "Last Modified on"
 msgstr "Última modificación el"
 
@@ -213,6 +201,21 @@ msgstr "Última actualización por"
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__write_date
 msgid "Last Updated on"
 msgstr "Última actualización el"
+
+#. module: project_timesheet_time_control
+#: model:ir.model,name:project_timesheet_time_control.model_hr_timesheet_time_control_mixin
+msgid "Mixin for records related with timesheet lines"
+msgstr "Mixin para registros relacionados con líneas de parte de horas"
+
+#. module: project_timesheet_time_control
+#: code:addons/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py:73
+#, python-format
+msgid ""
+"No running timer found in %(model)s %(record)s. Refresh the page and check "
+"again."
+msgstr ""
+"No se ha encontrado ningún cronómetro corriendo en el/la %(model)s "
+"%(record)s. Refresque la página y pruebe de nuevo."
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__partner_id
@@ -236,11 +239,6 @@ msgid "Previous timer start"
 msgstr "Comienzo del cronómetro anterior"
 
 #. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__product_id
-msgid "Product"
-msgstr ""
-
-#. module: project_timesheet_time_control
 #: model:ir.model,name:project_timesheet_time_control.model_project_project
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__project_id
 msgid "Project"
@@ -252,18 +250,13 @@ msgid "Quantity"
 msgstr "Cantidad"
 
 #. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__ref
-msgid "Ref."
-msgstr ""
-
-#. module: project_timesheet_time_control
 #: selection:account.analytic.line,show_time_control:0
 #: selection:hr.timesheet.switch,show_time_control:0
 msgid "Resume"
 msgstr "Continuar"
 
 #. module: project_timesheet_time_control
-#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:71
+#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:61
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.account_analytic_line_tree
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_line_form
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_kanban_account_analytic_line
@@ -275,12 +268,14 @@ msgstr "Continuar trabajo"
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_account_analytic_line__show_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__show_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_time_control_mixin__show_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_project_project__show_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_project_task__show_time_control
 msgid "Show Time Control"
 msgstr "Mostrar controles del cronómetro"
 
 #. module: project_timesheet_time_control
+#: selection:hr.timesheet.time_control.mixin,show_time_control:0
 #: selection:project.project,show_time_control:0
 #: selection:project.task,show_time_control:0
 msgid "Start"
@@ -292,8 +287,7 @@ msgid "Start new timer"
 msgstr "Comenzar nuevo cronómetro"
 
 #. module: project_timesheet_time_control
-#: code:addons/project_timesheet_time_control/models/project_project.py:50
-#: code:addons/project_timesheet_time_control/models/project_task.py:50
+#: code:addons/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py:59
 #: model:ir.actions.act_window,name:project_timesheet_time_control.hr_timesheet_switch_action
 #: model:ir.ui.menu,name:project_timesheet_time_control.hr_timesheet_switch_menu
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.project_invoice_form
@@ -308,6 +302,7 @@ msgstr "Comenzar trabajo"
 #. module: project_timesheet_time_control
 #: selection:account.analytic.line,show_time_control:0
 #: selection:hr.timesheet.switch,show_time_control:0
+#: selection:hr.timesheet.time_control.mixin,show_time_control:0
 #: selection:project.project,show_time_control:0
 #: selection:project.task,show_time_control:0
 msgid "Stop"

--- a/project_timesheet_time_control/i18n/project_timesheet_time_control.pot
+++ b/project_timesheet_time_control/i18n/project_timesheet_time_control.pot
@@ -1,11 +1,13 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* project_timesheet_time_control
+#       * project_timesheet_time_control
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-10-15 09:35+0000\n"
+"PO-Revision-Date: 2019-10-15 09:35+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -62,7 +64,7 @@ msgid "Cancel"
 msgstr ""
 
 #. module: project_timesheet_time_control
-#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:86
+#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:76
 #, python-format
 msgid "Cannot stop timer %d because it is not running. Refresh the page and check again."
 msgstr ""
@@ -70,11 +72,6 @@ msgstr ""
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__is_task_closed
 msgid "Closed"
-msgstr ""
-
-#. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__code
-msgid "Code"
 msgstr ""
 
 #. module: project_timesheet_time_control
@@ -123,17 +120,13 @@ msgstr ""
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__display_name
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_time_control_mixin__display_name
 msgid "Display Name"
 msgstr ""
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__employee_id
 msgid "Employee"
-msgstr ""
-
-#. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__general_account_id
-msgid "Financial Account"
 msgstr ""
 
 #. module: project_timesheet_time_control
@@ -148,24 +141,22 @@ msgstr ""
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__id
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_time_control_mixin__id
 msgid "ID"
 msgstr ""
 
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,help:project_timesheet_time_control.field_account_analytic_line__show_time_control
 #: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__show_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_time_control_mixin__show_time_control
 #: model:ir.model.fields,help:project_timesheet_time_control.field_project_project__show_time_control
 #: model:ir.model.fields,help:project_timesheet_time_control.field_project_task__show_time_control
 msgid "Indicate which time control button to show, if any."
 msgstr ""
 
 #. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__move_id
-msgid "Journal Item"
-msgstr ""
-
-#. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch____last_update
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_time_control_mixin____last_update
 msgid "Last Modified on"
 msgstr ""
 
@@ -177,6 +168,17 @@ msgstr ""
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__write_date
 msgid "Last Updated on"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model,name:project_timesheet_time_control.model_hr_timesheet_time_control_mixin
+msgid "Mixin for records related with timesheet lines"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: code:addons/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py:73
+#, python-format
+msgid "No running timer found in %(model)s %(record)s. Refresh the page and check again."
 msgstr ""
 
 #. module: project_timesheet_time_control
@@ -201,11 +203,6 @@ msgid "Previous timer start"
 msgstr ""
 
 #. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__product_id
-msgid "Product"
-msgstr ""
-
-#. module: project_timesheet_time_control
 #: model:ir.model,name:project_timesheet_time_control.model_project_project
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__project_id
 msgid "Project"
@@ -217,18 +214,13 @@ msgid "Quantity"
 msgstr ""
 
 #. module: project_timesheet_time_control
-#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__ref
-msgid "Ref."
-msgstr ""
-
-#. module: project_timesheet_time_control
 #: selection:account.analytic.line,show_time_control:0
 #: selection:hr.timesheet.switch,show_time_control:0
 msgid "Resume"
 msgstr ""
 
 #. module: project_timesheet_time_control
-#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:71
+#: code:addons/project_timesheet_time_control/models/account_analytic_line.py:61
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.account_analytic_line_tree
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_line_form
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.view_kanban_account_analytic_line
@@ -240,12 +232,14 @@ msgstr ""
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_account_analytic_line__show_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__show_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_time_control_mixin__show_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_project_project__show_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_project_task__show_time_control
 msgid "Show Time Control"
 msgstr ""
 
 #. module: project_timesheet_time_control
+#: selection:hr.timesheet.time_control.mixin,show_time_control:0
 #: selection:project.project,show_time_control:0
 #: selection:project.task,show_time_control:0
 msgid "Start"
@@ -257,8 +251,7 @@ msgid "Start new timer"
 msgstr ""
 
 #. module: project_timesheet_time_control
-#: code:addons/project_timesheet_time_control/models/project_project.py:50
-#: code:addons/project_timesheet_time_control/models/project_task.py:50
+#: code:addons/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py:59
 #: model:ir.actions.act_window,name:project_timesheet_time_control.hr_timesheet_switch_action
 #: model:ir.ui.menu,name:project_timesheet_time_control.hr_timesheet_switch_menu
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.project_invoice_form
@@ -273,6 +266,7 @@ msgstr ""
 #. module: project_timesheet_time_control
 #: selection:account.analytic.line,show_time_control:0
 #: selection:hr.timesheet.switch,show_time_control:0
+#: selection:hr.timesheet.time_control.mixin,show_time_control:0
 #: selection:project.project,show_time_control:0
 #: selection:project.task,show_time_control:0
 msgid "Stop"
@@ -360,4 +354,3 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
 msgid "hour(s)."
 msgstr ""
-

--- a/project_timesheet_time_control/models/__init__.py
+++ b/project_timesheet_time_control/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
 from . import account_analytic_line
+from . import hr_timesheet_time_control_mixin
 from . import project_project
 from . import project_task

--- a/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py
+++ b/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py
@@ -1,0 +1,76 @@
+# Copyright 2019 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import _, api, models, fields
+from odoo.exceptions import UserError
+
+
+class HrTimesheetTimeControlMixin(models.AbstractModel):
+    _name = "hr.timesheet.time_control.mixin"
+    _description = "Mixin for records related with timesheet lines"
+
+    show_time_control = fields.Selection(
+        selection=[("start", "Start"), ("stop", "Stop")],
+        compute="_compute_show_time_control",
+        help="Indicate which time control button to show, if any.",
+    )
+
+    @api.model
+    def _relation_with_timesheet_line(self):
+        """Name of the field that relates this model with AAL."""
+        raise NotImplementedError
+
+    @api.model
+    def _timesheet_running_domain(self):
+        """Domain to find running timesheet lines."""
+        return self.env["account.analytic.line"]._running_domain() + [
+            (self._relation_with_timesheet_line(), "in", self.ids),
+        ]
+
+    def _compute_show_time_control(self):
+        """Decide which time control button to show, if any."""
+        related_field = self._relation_with_timesheet_line()
+        grouped = self.env["account.analytic.line"].read_group(
+            domain=self._timesheet_running_domain(),
+            fields=["id"],
+            groupby=[related_field],
+        )
+        lines_per_record = {
+            group[related_field][0]: group["%s_count" % related_field]
+            for group in grouped
+        }
+        button_per_lines = {0: "start", 1: "stop"}
+        for record in self:
+            record.show_time_control = button_per_lines.get(
+                lines_per_record.get(record.id, 0),
+                False,
+            )
+
+    def button_start_work(self):
+        """Create a new record starting now, with a running timer."""
+        related_field = self._relation_with_timesheet_line()
+        return {
+            "context": {
+                "default_%s" % related_field: self.id,
+            },
+            "name": _("Start work"),
+            "res_model": "hr.timesheet.switch",
+            "target": "new",
+            "type": "ir.actions.act_window",
+            "view_mode": "form",
+            "view_type": "form",
+        }
+
+    def button_end_work(self):
+        running_lines = self.env["account.analytic.line"].search(
+            self._timesheet_running_domain(),
+        )
+        if not running_lines:
+            model = self.env["ir.model"].search([("model", "=", self._name)])
+            message = _("No running timer found in %(model)s %(record)s. "
+                        "Refresh the page and check again.")
+            raise UserError(message % {
+                "model": model.name,
+                "record": self.display_name
+            })
+        return running_lines.button_end_work()

--- a/project_timesheet_time_control/models/project_project.py
+++ b/project_timesheet_time_control/models/project_project.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class ProjectProject(models.Model):
@@ -60,4 +61,9 @@ class ProjectProject(models.Model):
         running_lines = self.env["account.analytic.line"].search(
             self._timesheet_running_domain(),
         )
+        if not running_lines:
+            raise UserError(
+                _("No running timer found in project %s. "
+                  "Refresh the page and check again.") % self.display_name,
+            )
         return running_lines.button_end_work()

--- a/project_timesheet_time_control/models/project_project.py
+++ b/project_timesheet_time_control/models/project_project.py
@@ -1,69 +1,30 @@
 # Copyright 2019 Tecnativa - Jairo Llopis
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo import api, models
 
 
 class ProjectProject(models.Model):
-    _inherit = "project.project"
-
-    show_time_control = fields.Selection(
-        selection=[("start", "Start"), ("stop", "Stop")],
-        compute="_compute_show_time_control",
-        help="Indicate which time control button to show, if any.",
-    )
+    _name = "project.project"
+    _inherit = ["project.project", "hr.timesheet.time_control.mixin"]
 
     @api.model
-    def _timesheet_running_domain(self):
-        """Domain to find running timesheet lines."""
-        return self.env["account.analytic.line"]._running_domain() + [
-            ("project_id", "in", self.ids),
-        ]
+    def _relation_with_timesheet_line(self):
+        return "project_id"
 
     @api.depends("allow_timesheets")
     def _compute_show_time_control(self):
-        """Decide which time control button to show, if any."""
-        grouped = self.env["account.analytic.line"].read_group(
-            domain=self._timesheet_running_domain(),
-            fields=["id"],
-            groupby=["project_id"],
-        )
-        lines_per_project = {group["project_id"][0]: group["project_id_count"]
-                             for group in grouped}
-        button_per_lines = {0: "start", 1: "stop"}
+        result = super()._compute_show_time_control()
         for project in self:
+            # Never show button if timesheets are not allowed in project
             if not project.allow_timesheets:
                 project.show_time_control = False
-                continue
-            project.show_time_control = button_per_lines.get(
-                lines_per_project.get(project.id, 0),
-                False,
-            )
+        return result
 
     def button_start_work(self):
-        """Create a new record starting now, with a running timer."""
-        return {
-            "context": {
-                "default_project_id": self.id,
-                "default_task_id": False,
-            },
-            "name": _("Start work"),
-            "res_model": "hr.timesheet.switch",
-            "target": "new",
-            "type": "ir.actions.act_window",
-            "view_mode": "form",
-            "view_type": "form",
-        }
-
-    @api.multi
-    def button_end_work(self):
-        running_lines = self.env["account.analytic.line"].search(
-            self._timesheet_running_domain(),
-        )
-        if not running_lines:
-            raise UserError(
-                _("No running timer found in project %s. "
-                  "Refresh the page and check again.") % self.display_name,
-            )
-        return running_lines.button_end_work()
+        result = super().button_start_work()
+        # When triggering from project is usually to start timer without task
+        result["context"].update({
+            "default_task_id": False,
+        })
+        return result

--- a/project_timesheet_time_control/models/project_task.py
+++ b/project_timesheet_time_control/models/project_task.py
@@ -1,69 +1,30 @@
 # Copyright 2019 Tecnativa - Jairo Llopis
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo import api, models
 
 
 class ProjectTask(models.Model):
-    _inherit = "project.task"
-
-    show_time_control = fields.Selection(
-        selection=[("start", "Start"), ("stop", "Stop")],
-        compute="_compute_show_time_control",
-        help="Indicate which time control button to show, if any.",
-    )
+    _name = "project.task"
+    _inherit = ["project.task", "hr.timesheet.time_control.mixin"]
 
     @api.model
-    def _timesheet_running_domain(self):
-        """Domain to find running timesheet lines."""
-        return self.env["account.analytic.line"]._running_domain() + [
-            ("task_id", "in", self.ids),
-        ]
+    def _relation_with_timesheet_line(self):
+        return "task_id"
 
-    @api.depends("timesheet_ids.employee_id", "timesheet_ids.unit_amount")
+    @api.depends("project_id.allow_timesheets", "timesheet_ids.employee_id",
+                 "timesheet_ids.unit_amount")
     def _compute_show_time_control(self):
-        """Decide which time control button to show, if any."""
-        grouped = self.env["account.analytic.line"].read_group(
-            domain=self._timesheet_running_domain(),
-            fields=["id"],
-            groupby=["task_id"],
-        )
-        lines_per_task = {group["task_id"][0]: group["task_id_count"]
-                          for group in grouped}
-        button_per_lines = {0: "start", 1: "stop"}
+        result = super()._compute_show_time_control()
         for task in self:
+            # Never show button if timesheets are not allowed in project
             if not task.project_id.allow_timesheets:
                 task.show_time_control = False
-                continue
-            task.show_time_control = button_per_lines.get(
-                lines_per_task.get(task.id, 0),
-                False,
-            )
+        return result
 
     def button_start_work(self):
-        """Create a new record starting now, with a running timer."""
-        return {
-            "context": {
-                "default_project_id": self.project_id.id,
-                "default_task_id": self.id,
-            },
-            "name": _("Start work"),
-            "res_model": "hr.timesheet.switch",
-            "target": "new",
-            "type": "ir.actions.act_window",
-            "view_mode": "form",
-            "view_type": "form",
-        }
-
-    @api.multi
-    def button_end_work(self):
-        running_lines = self.env["account.analytic.line"].search(
-            self._timesheet_running_domain(),
-        )
-        if not running_lines:
-            raise UserError(
-                _("No running timer found in task %s this record. "
-                  "Refresh the page and check again.") % self.display_name,
-            )
-        return running_lines.button_end_work()
+        result = super().button_start_work()
+        result["context"].update({
+            "default_project_id": self.project_id.id,
+        })
+        return result

--- a/project_timesheet_time_control/models/project_task.py
+++ b/project_timesheet_time_control/models/project_task.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
+from odoo.exceptions import UserError
 
 
 class ProjectTask(models.Model):
@@ -60,4 +61,9 @@ class ProjectTask(models.Model):
         running_lines = self.env["account.analytic.line"].search(
             self._timesheet_running_domain(),
         )
+        if not running_lines:
+            raise UserError(
+                _("No running timer found in task %s this record. "
+                  "Refresh the page and check again.") % self.display_name,
+            )
         return running_lines.button_end_work()

--- a/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -148,6 +148,9 @@ class TestProjectTimesheetTimeControl(common.TransactionCase):
         self.project.invalidate_cache()
         self.assertEqual(self.project.show_time_control, "stop")
         self.project.button_end_work()
+        # No more running lines, cannot stop again
+        with self.assertRaises(exceptions.UserError):
+            self.project.button_end_work()
         # All lines stopped, start new one
         self.project.invalidate_cache()
         self.assertEqual(self.project.show_time_control, "start")
@@ -179,6 +182,9 @@ class TestProjectTimesheetTimeControl(common.TransactionCase):
         # Running line found, stop the timer
         self.assertEqual(self.task.show_time_control, "stop")
         self.task.button_end_work()
+        # No more running lines, cannot stop again
+        with self.assertRaises(exceptions.UserError):
+            self.task.button_end_work()
         # All lines stopped, start new one
         self.task.invalidate_cache()
         self.assertEqual(self.task.show_time_control, "start")


### PR DESCRIPTION
Imagine this scenario:

1. In tab 1 of the browser, you have opened task 1.
2. In tab 2 of the browser, you have opened task 2.
3. You go to tab 1 and start a timer.
4. Work, work, work...
5. You go to tab 2 and start a timer, stopping that of task 1.
6. Work, work, work...
7. You go to tab 1 and see that timer as running (it is not, but you didn't refresh). You hit stop.

Before this commit, it just seemed like the timer was actually stopped. What did happen behind the scenes is that your view was refreshed, but no timer was touched fortunately.

After this commit, you get a message telling you that there's no timer to stop and that your browser is most likely out of sync. This mimics the behavior previously found when doing the same, but directly in the AAL. Now it's present in projects and tasks too.

@Tecnativa TT19205 https://github.com/OCA/timesheet/pull/280