### PR TITLE
[FIX] Set new_name to the template name as default

### DIFF
--- a/project_template/models/project.py
+++ b/project_template/models/project.py
@@ -10,6 +10,7 @@ class Project(models.Model):
 
     # CREATE A PROJECT FROM A TEMPLATE AND OPEN THE NEWLY CREATED PROJECT
     def create_project_from_template(self):
+        new_name = self.name
         if " (TEMPLATE)" in self.name:
             new_name = self.name.replace(" (TEMPLATE)", " (COPY)")
 


### PR DESCRIPTION
 to avoid unbound var exception if (TEMPLATE) is not in name

  File "/opt/odoo/oca/project/project_template/models/project.py", line 16, in create_project_from_template
    new_project = self.copy(default={'name': new_name,
UnboundLocalError: local variable 'new_name' referenced before assignment