### PR TITLE
[12.0] [FIX] [project_purchase_link] Fixed translation error

### DIFF
--- a/project_purchase_link/i18n/es.po
+++ b/project_purchase_link/i18n/es.po
@@ -1,16 +1,15 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-# 	* project_purchase_utilities
+#	* project_purchase_link
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 11.0\n"
+"Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-25 08:47+0000\n"
-"PO-Revision-Date: 2019-01-25 08:47+0000\n"
+"POT-Creation-Date: 2019-11-26 14:35+0000\n"
+"PO-Revision-Date: 2019-11-26 14:35+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -27,6 +26,11 @@ msgid "# Purchase Invoice"
 msgstr "N.º de facturas de compra"
 
 #. module: project_purchase_link
+#: model:ir.model,name:project_purchase_link.model_project_project
+msgid "Project"
+msgstr "Proyecto"
+
+#. module: project_purchase_link
 #: code:addons/project_purchase_link/models/project_project.py:100
 #, python-format
 msgid "Purchase Invoice Lines"
@@ -35,7 +39,6 @@ msgstr "Líneas de factura de compra"
 #. module: project_purchase_link
 #: model:ir.model.fields,field_description:project_purchase_link.field_project_project__purchase_invoice_line_total
 #: model_terms:ir.ui.view,arch_db:project_purchase_link.project_project_view_form
-#, fuzzy
 msgid "Purchase Invoice Total"
 msgstr "Facturas de compra"
 
@@ -59,7 +62,6 @@ msgstr "Líneas de pedido de compra"
 #. module: project_purchase_link
 #: model:ir.model.fields,field_description:project_purchase_link.field_project_project__purchase_line_total
 #: model_terms:ir.ui.view,arch_db:project_purchase_link.project_project_view_form
-#, fuzzy
 msgid "Purchase Total"
 msgstr "Compras"
 
@@ -68,13 +70,3 @@ msgstr "Compras"
 msgid "Purchases"
 msgstr "Compras"
 
-#. module: project_purchase_link
-#: model:ir.model,name:project_purchase_link.model_project_project
-msgid "WBS element"
-msgstr ""
-
-#~ msgid "Project"
-#~ msgstr "Proyecto"
-
-#~ msgid "Purchase Lines"
-#~ msgstr "Líneas de compra"


### PR DESCRIPTION
I've found some issues regarding the translation of 'project_purchase_link'.

The name of the module is 'project_purchase_link' but the name found in the translation file is ['project_purchase_utilities'](https://github.com/OCA/project/blob/e7908ec58d19aa81518b1bf5a465cc4e52f16a11/project_purchase_link/i18n/es.po#L3).

And the translations that are found at [the end of the file](https://github.com/OCA/project/blob/e7908ec58d19aa81518b1bf5a465cc4e52f16a11/project_purchase_link/i18n/es.po#L71) aren't used:
```
#. module: project_purchase_link
#: model:ir.model,name:project_purchase_link.model_project_project
msgid "WBS element"
msgstr ""

#~ msgid "Project"
#~ msgstr "Proyecto"

#~ msgid "Purchase Lines"
#~ msgstr "Líneas de compra"
```
