### PR TITLE
[10.0][IMP] enable quick search by code field for tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache: pip
 
 python:
-  - "2.7.13"
+  - "2.7"
 
 addons:
   postgresql: "9.6"
@@ -23,6 +23,9 @@ env:
   - LINT_CHECK="1"
   - TESTS="1" ODOO_REPO="odoo/odoo" MAKEPOT="1"
   - TESTS="1" ODOO_REPO="OCA/OCB"
+
+virtualenv:
+  system_site_packages: true
 
 install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools

--- a/project_task_code/__init__.py
+++ b/project_task_code/__init__.py
@@ -5,6 +5,7 @@
 from . import models
 from odoo import api, SUPERUSER_ID
 
+
 def create_code_equal_to_id(cr):
     """
     With this pre-init-hook we want to avoid error when creating the UNIQUE

--- a/project_task_code/__manifest__.py
+++ b/project_task_code/__manifest__.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Tecnativa <vicent.cubells@tecnativa.com>
+# Copyright 2020 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {
     "name": "Sequential Code for Tasks",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Project Management",
     "author": "OdooMRP team, "
               "AvanzOSC, "
@@ -17,6 +18,7 @@
         "Pedro M. Baeza <pedro.baeza@serviciosbaeza.com>",
         "Ana Juaristi <ajuaristo@gmail.com>",
         "Vicent Cubells <vicent.cubells@tecnativa.com>",
+        "Nikos Tsirintanis <ntsirintanis@therp.nl>",
     ],
     "depends": [
         "project",

--- a/project_task_code/models/project_task.py
+++ b/project_task_code/models/project_task.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Tecnativa <vicent.cubells@tecnativa.com>
+# Copyright 2020 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openerp import api, fields, models, _
@@ -28,3 +29,41 @@ class ProjectTask(models.Model):
             default = {}
         default['code'] = self.env['ir.sequence'].next_by_code('project.task')
         return super(ProjectTask, self).copy(default)
+
+    @api.model
+    def name_search(self, name='', args=None, operator='ilike', limit=100):
+        args = args or []
+        tasks = []
+        code = self._name_search_parse_code(name)
+        if code:
+            # We are searching for codes
+            tasks = self.search(
+                [('code', '=ilike', code + '%')] + args,
+                limit=limit).name_get()
+            if limit and len(tasks) == limit:
+                return tasks
+        additional_args = args + [('id', 'not in', [i[0] for i in tasks])]
+        return tasks + super(ProjectTask, self).name_search(
+            name=name,
+            args=additional_args,
+            operator=operator,
+            limit=limit and limit - len(tasks) or limit)
+
+    @api.model
+    def _name_search_parse_code(self, name):
+        """ Check if user input looks like code """
+        # Remove any whitespace from name
+        name = name.lstrip()
+        # Get the data record
+        sequence_id = self.env.ref('project_task_code.sequence_task')
+        prefix = sequence_id.prefix or ''
+        # if user is typing only digits, return right away
+        if name.isdigit():
+            return prefix + name
+        # Check if input could be code
+        if (
+            name.startswith(prefix) and
+            name[len(prefix): len(name)].isdigit(),
+        ):
+            return name
+        return False

--- a/project_task_code/models/project_task.py
+++ b/project_task_code/models/project_task.py
@@ -38,7 +38,7 @@ class ProjectTask(models.Model):
         if code:
             # We are searching for codes
             tasks = self.search(
-                [('code', '=ilike', code + '%')] + args,
+                [('code', '=ilike', code)] + args,
                 limit=limit).name_get()
             if limit and len(tasks) == limit:
                 return tasks

--- a/project_task_code/tests/test_project_task_code.py
+++ b/project_task_code/tests/test_project_task_code.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Tecnativa <vicent.cubells@tecnativa.com>
+# Copyright 2020 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import openerp.tests.common as common
@@ -34,3 +35,16 @@ class TestProjectTaskCode(common.TransactionCase):
         project_task_copy = self.project_task.copy()
         self.assertNotEqual(project_task_copy.code, self.project_task.code)
         self.assertEqual(project_task_copy.code, code)
+
+    def test_name_search(self):
+        tasks = self.project_task_model
+        for i in range(10):
+            task = tasks.create({'name': 'task0%s' % str(i)})
+            tasks += task
+        for task in tasks:
+            self.assertEqual(
+                task,
+                tasks.browse(tasks.name_search(name=task.code)[0][0]))
+            self.assertEqual(
+                tasks.name_search(name=task.code),
+                tasks.name_search(name=task.name))

--- a/project_task_code/tests/test_project_task_code.py
+++ b/project_task_code/tests/test_project_task_code.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016 Tecnativa <vicent.cubells@tecnativa.com>
-# Copyright 2020 Therp BV <http://therp.nl>
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+# Copyright 2020 Therp BV <https://therp.nl>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 import openerp.tests.common as common
 


### PR DESCRIPTION
An update for `product_task_code`, enabling the user to search for tasks using the `code` field. This was done by editing `name_search()`.