### PR TITLE
[FIX] Convert datetime into date with timezone

### DIFF
--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -25,8 +25,13 @@ class AccountAnalyticLine(models.Model):
     @api.model
     def _eval_date(self, vals):
         if vals.get('date_time'):
-            return dict(vals, date=fields.Date.to_date(vals['date_time']))
+            return dict(vals, date=self._convert_datetime_to_date(vals['date_time']))
         return vals
+
+    def _convert_datetime_to_date(self, datetime_):
+        if isinstance(datetime_, str):
+            datetime_ = fields.Datetime.from_string(datetime_)
+        return fields.Date.context_today(self, datetime_)
 
     @api.model
     def _running_domain(self):

--- a/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -2,7 +2,7 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0
 
 from odoo.tests import common
-from odoo import exceptions, fields
+from odoo import exceptions
 from datetime import timedelta, date, datetime
 
 

--- a/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -60,15 +60,30 @@ class TestProjectTimesheetTimeControl(common.TransactionCase):
         self.line.employee_id = self.other_employee
         self.assertFalse(self.line.show_time_control)
 
-    def test_create_write_analytic_line(self):
-        line = self.env['account.analytic.line'].create({
-            'date_time': fields.Datetime.now(),
+    def test_create_analytic_line(self):
+        line = self._create_analytic_line(datetime(2016, 3, 24, 3), tz="EST")
+        self.assertEqual(line.date, date(2016, 3, 23))
+
+    def test_create_analytic_line_with_string_datetime(self):
+        line = self._create_analytic_line('2016-03-24 03:00:00', tz="EST")
+        self.assertEqual(line.date, date(2016, 3, 23))
+
+    def test_write_analytic_line(self):
+        line = self._create_analytic_line(datetime.now())
+        line.with_context(tz="EST").date_time = '2016-03-24 03:00:00'
+        self.assertEqual(line.date, date(2016, 3, 23))
+
+    def test_write_analytic_line_with_string_datetime(self):
+        line = self._create_analytic_line(datetime.now())
+        line.with_context(tz="EST").date_time = datetime(2016, 3, 24, 3)
+        self.assertEqual(line.date, date(2016, 3, 23))
+
+    def _create_analytic_line(self, datetime_, tz=None):
+        return self.env['account.analytic.line'].with_context(tz=tz).create({
+            'date_time': datetime_,
             'project_id': self.project.id,
             'name': 'Test line',
         })
-        self.assertEqual(line.date, fields.Date.today())
-        line.date_time = '2016-03-23 18:27:00'
-        self.assertEqual(line.date, date(2016, 3, 23))
 
     def test_aal_time_control_flow(self):
         """Test account.analytic.line time controls."""


### PR DESCRIPTION
Before this fix, as a user, if you entered a timesheet with a given datetime,
the timesheet could actually be stored as another date in the database.

This falsifies the grid view and other reports that group analytic lines per date.