### PR TITLE
[12.0] remove criticalpath from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
   - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:$PATH
   - travis_install_nightly
-  - pip install criticalpath
 
 script:
   - travis_run_tests


### PR DESCRIPTION
Import not found in the addons' code.