### PR TITLE
[FIX][13.0] project_category can now be migrated from 11.0 to 13.0

### DIFF
--- a/project_category/views/project_type_views.xml
+++ b/project_category/views/project_type_views.xml
@@ -45,6 +45,7 @@
     </record>
     <record id="project_type_search" model="ir.ui.view">
         <field name="model">project.type</field>
+        <field name="inherit_id" eval="False"/>
         <field name="arch" type="xml">
             <search string="Type">
                 <field name="complete_name" />

--- a/project_category/views/project_type_views.xml
+++ b/project_category/views/project_type_views.xml
@@ -45,7 +45,7 @@
     </record>
     <record id="project_type_search" model="ir.ui.view">
         <field name="model">project.type</field>
-        <field name="inherit_id" eval="False"/>
+        <field name="inherit_id" eval="False" />
         <field name="arch" type="xml">
             <search string="Type">
                 <field name="complete_name" />


### PR DESCRIPTION
In commit 26a7e26481bc35306ed9aacfb0d2f26bbf78a37d the view `project_type_search` of `project.project` was renamed to `project_search` and there was a new view introduced with the same XML ID, but for a different model, `project.type`. This means that the `inherit_id` field of that view still contains the old value of `project.view_project_project_filter` and obviously that view shouldn't inherit any other view. Thus the `inherit_id` is explicitly set to `False`.

PR for version 12.0 here: #666 :smiling_imp: 