### PR TITLE
[13.0][FIX] project_timesheet_time_control: fix compatibility with hr_timesheet_activity_begin_end module

### DIFF
--- a/project_timesheet_time_control/wizards/hr_timesheet_switch.py
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch.py
@@ -114,6 +114,11 @@ class HrTimesheetSwitch(models.TransientModel):
                 # resume an invoiced AAL if that module is installed,
                 # and it doesn't hurt here
                 "timesheet_invoice_id",
+                # These fields are from the hr_timesheet_activity_begin_end
+                # module. Unless ignored, these fields will cause a validation
+                # error because time_stop - time_start must equal duration.
+                "time_start",
+                "time_stop",
             }
             inherited.read(_fields)
             values = inherited._convert_to_write(inherited._cache)


### PR DESCRIPTION
Fixes a compatibility issue with [this module](https://github.com/OCA/timesheet/tree/13.0/hr_timesheet_activity_begin_end)

Prior to this commit, trying to resume an activity which had a start time or end time set would cause the newly created timesheet to throw a validation error because time_stop - time_start must equal duration. This commit fixes that issues by adding those fields to the ignore list.