### PR TITLE
[13.0][IMP] project_timesheet_time_control: add a field for the end time of a timesheet

### DIFF
--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -5,6 +5,8 @@
 
 from datetime import datetime
 
+from dateutil.relativedelta import relativedelta
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
@@ -13,12 +15,42 @@ class AccountAnalyticLine(models.Model):
     _inherit = "account.analytic.line"
     _order = "date_time desc"
 
-    date_time = fields.Datetime(default=fields.Datetime.now, copy=False)
+    date_time = fields.Datetime(
+        string="Start Time", default=fields.Datetime.now, copy=False
+    )
+    date_time_end = fields.Datetime(
+        string="End Time",
+        compute="_compute_date_time_end",
+        inverse="_inverse_date_time_end",
+    )
     show_time_control = fields.Selection(
         selection=[("resume", "Resume"), ("stop", "Stop")],
         compute="_compute_show_time_control",
         help="Indicate which time control button to show, if any.",
     )
+
+    @api.depends("date_time", "unit_amount", "product_uom_id")
+    def _compute_date_time_end(self):
+        hour_uom = self.env.ref("uom.product_uom_hour")
+        for record in self:
+            if (
+                record.product_uom_id == hour_uom
+                and record.date_time
+                and record.unit_amount
+            ):
+                record.date_time_end = record.date_time + relativedelta(
+                    hours=record.unit_amount
+                )
+            else:
+                record.date_time_end = record.date_time_end
+
+    def _inverse_date_time_end(self):
+        hour_uom = self.env.ref("uom.product_uom_hour")
+        for record in self.filtered(lambda x: x.date_time and x.date_time_end):
+            if record.product_uom_id == hour_uom:
+                record.unit_amount = (
+                    record.date_time_end - record.date_time
+                ).seconds / 3600
 
     @api.model
     def _eval_date(self, vals):

--- a/project_timesheet_time_control/views/account_analytic_line_view.xml
+++ b/project_timesheet_time_control/views/account_analytic_line_view.xml
@@ -8,7 +8,8 @@
                 <attribute name="invisible">1</attribute>
             </field>
             <field name="date" position="after">
-                <field name="date_time" string="Date" required="1" />
+                <field name="date_time" required="1" />
+                <field name="date_time_end" optional="hide" />
             </field>
             <field name="unit_amount" position="after">
                 <field name="show_time_control" invisible="1" />
@@ -65,7 +66,8 @@
                 <attribute name="invisible">1</attribute>
             </field>
             <field name="date" position="after">
-                <field name="date_time" string="Date" required="1" />
+                <field name="date_time" required="1" />
+                <field name="date_time_end" />
             </field>
         </field>
     </record>
@@ -94,7 +96,8 @@
                 />
             </xpath>
             <field name="date" position="after">
-                <field name="date_time" required="1" />
+                <field name="date_time" />
+                <field name="date_time_end" />
             </field>
             <xpath
                 expr="//templates//t[@t-esc='record.date.value']"
@@ -104,6 +107,11 @@
             </xpath>
             <xpath expr="//templates//t[@t-esc='record.date.value']" position="after">
                 <t t-esc="record.date_time.value" />
+                <t t-if="record.date_time_end.value">
+                    <br />
+                    <span>to</span>
+                    <t t-esc="record.date_time_end.value" />
+                </t>
             </xpath>
         </field>
     </record>

--- a/project_timesheet_time_control/wizards/hr_timesheet_switch.py
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch.py
@@ -106,6 +106,7 @@ class HrTimesheetSwitch(models.TransientModel):
                 "id",
                 "amount",
                 "date_time",
+                "date_time_end",
                 "date",
                 "is_task_closed",
                 "unit_amount",


### PR DESCRIPTION
This commit adds a field to the timesheet to store the end time. It is not required to enter the end time, if it is not entered it is calculated automatically by comparing the start time and the duration, if only a start time and end time are entered, then the duration is calculated accordingly. The end time field is set to optional in the tree view.