### PR TITLE
[12.0] FIX project_timesheet_time_control when not using employees

### DIFF
--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -38,7 +38,7 @@ class AccountAnalyticLine(models.Model):
         """Domain to find running timesheet lines."""
         return [
             ("date_time", "!=", False),
-            ("employee_id", "in", self.env.user.employee_ids.ids),
+            ("user_id", "=", self.env.user.id),
             ("project_id.allow_timesheets", "=", True),
             ("unit_amount", "=", 0),
         ]


### PR DESCRIPTION
Otherwise, when not using employees:

![stop](https://user-images.githubusercontent.com/1033131/92690101-99ae1280-f340-11ea-8bf3-70e2d5e30eef.gif)
