### PR TITLE
[IMP] project_task_code: support already initialized code column

### DIFF
--- a/project_task_code/hooks.py
+++ b/project_task_code/hooks.py
@@ -10,10 +10,10 @@ def pre_init_hook(cr):
     code constraint when the module is installed and before the post-init-hook
     is launched.
     """
-    cr.execute('ALTER TABLE project_task '
-               'ADD COLUMN code character varying;')
-    cr.execute('UPDATE project_task '
-               'SET code = id;')
+    cr.execute(
+        "ALTER TABLE project_task ADD COLUMN IF NOT EXISTS code character varying"
+    )
+    cr.execute("UPDATE project_task SET code = id WHERE code IS NULL")
 
 
 def post_init_hook(cr, registry):
@@ -22,11 +22,14 @@ def post_init_hook(cr, registry):
     corresponding sequence code.
     """
     env = api.Environment(cr, SUPERUSER_ID, dict())
-    task_obj = env['project.task']
-    sequence_obj = env['ir.sequence']
-    tasks = task_obj.search([], order="id")
+    task_obj = env["project.task"]
+    sequence_obj = env["ir.sequence"]
+    tasks = task_obj.search([("code", "=", False)], order="id")
     for task_id in tasks.ids:
-        cr.execute('UPDATE project_task '
-                   'SET code = %s '
-                   'WHERE id = %s;',
-                   (sequence_obj.next_by_code('project.task'), task_id,))
+        cr.execute(
+            "UPDATE project_task " "SET code = %s " "WHERE id = %s;",
+            (
+                sequence_obj.next_by_code("project.task"),
+                task_id,
+            ),
+        )


### PR DESCRIPTION
Support the case where the database table already has a `code` column.
Only populate new task codes on records without  a task number set.
Code Blackified.