### PR TITLE
[13.0][FIX] project_key: avoid index out of range error

### DIFF
--- a/project_key/models/project_project.py
+++ b/project_key/models/project_project.py
@@ -138,7 +138,7 @@ class Project(models.Model):
 
         key = []
         for item in data:
-            key.append(item[0].upper())
+            key.append(item[:1].upper())
         return "".join(key)
 
     def _update_task_keys(self):


### PR DESCRIPTION
**Impacted versions:**
13.0

**Steps to reproduce:**

1. Open OCA project runbot instance
2. Uninstall project_key addon
3. Create new project  with a name with at least 2 spaces in a row (`Project   1`)
4. Install project_key addon

or

1. Create a new project with at least 2 spaces in a row in name
2. Leave the name field
3. Error

```
Odoo Server Error

Traceback (most recent call last):
  File "/.repo_requirements/odoo/odoo/http.py", line 656, in _handle_exception
    return super(JsonRequest, self)._handle_exception(exception)
  File "/.repo_requirements/odoo/odoo/http.py", line 314, in _handle_exception
    raise pycompat.reraise(type(exception), exception, sys.exc_info()[2])
  File "/.repo_requirements/odoo/odoo/tools/pycompat.py", line 87, in reraise
    raise value
  File "/.repo_requirements/odoo/odoo/http.py", line 698, in dispatch
    result = self._call_function(**self.params)
  File "/.repo_requirements/odoo/odoo/http.py", line 346, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/service/model.py", line 98, in wrapper
    return f(dbname, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 941, in __call__
    return self.method(*args, **kw)
  File "/.repo_requirements/odoo/odoo/http.py", line 519, in response_wrap
    response = f(*args, **kw)
  File "/home/odoo/OCB-13.0/addons/web/controllers/main.py", line 962, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/OCB-13.0/addons/web/controllers/main.py", line 954, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 759, in call_kw
    return _call_kw_multi(method, model, args, kwargs)
  File "/.repo_requirements/odoo/odoo/api.py", line 746, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/dependencies/server-tools/base_custom_info/models/custom_info.py", line 44, in onchange
    values, field_name, field_onchange,
  File "/.repo_requirements/odoo/odoo/models.py", line 5542, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File "/.repo_requirements/odoo/odoo/models.py", line 5386, in _onchange_eval
    method_res = method(self)
  File "/home/odoo/build/OCA/project/project_key/models/project_project.py", line 38, in _onchange_project_name
    rec.key = self.generate_project_key(rec.name)
  File "/home/odoo/build/OCA/project/project_key/models/project_project.py", line 154, in generate_project_key
    key.append(item[0].upper())
IndexError: string index out of range
```

**Current behavior:**

- Installation stops
`File "/opt/odoo/auto/addons/project_key/hooks.py", line 8, in post_init_hook
env['project.project']._set_default_project_key()
File "/opt/odoo/auto/addons/project_key/models/project_project.py", line 180, in _set_default_project_key
project.key = self.generate_project_key(project.name)
File "/opt/odoo/auto/addons/project_key/models/project_project.py", line 143, in generate_project_key
key.append(item[0].upper())
IndexError: string index out of range`


**Solution:**

This PR fixes index out of range error during project key generation and allows project_key addon installation.
Fixes #682

