### PR TITLE
[13.0][FIX] project_hr: forbid employee tag creation on project task form

### DIFF
--- a/project_hr/views/project_task_views.xml
+++ b/project_hr/views/project_task_views.xml
@@ -13,7 +13,11 @@
             <field name="user_id" position="before">
                 <field name="allowed_hr_category_ids" invisible="1" />
                 <field name="allowed_user_ids" invisible="1" />
-                <field name="hr_category_ids" widget="many2many_tags" />
+                <field
+                    name="hr_category_ids"
+                    widget="many2many_tags"
+                    options="{'no_create': True}"
+                />
             </field>
             <field name="user_id" position="attributes">
                 <attribute name="domain">[('id', 'in', allowed_user_ids)]</attribute>


### PR DESCRIPTION
**Impacted versions:**
13.0

**Steps to reproduce:**

1. Open OCA project runbot instance
2. Add employee category (tag) to a project
3. Create new task for that project
4. Open Employee Categories Drop Down and create new employee category
5. Save the task

Constraint warning appears

![project_hr_with_create](https://user-images.githubusercontent.com/226753/98556038-e8c1e680-22a2-11eb-9a40-59c322250e3c.png)
![project_hr_not_allowed_at_project_level](https://user-images.githubusercontent.com/226753/98556053-eb244080-22a2-11eb-9f55-08a441ec95d0.png)



**Solution:**

Allowed employee categories must be assigned on project level.
We can solve this by forbidden the creation of an employee category in project task form.

![project_hr_no_create](https://user-images.githubusercontent.com/226753/98555552-60434600-22a2-11eb-9c0a-8ba153bc32c3.png)




