### PR TITLE
[14.0][IMP] project_parent_task_filter: Activate subtasks on installation

### DIFF
--- a/project_parent_task_filter/__manifest__.py
+++ b/project_parent_task_filter/__manifest__.py
@@ -10,6 +10,6 @@
     "author": "C2i Change 2 improve, " "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["project"],
-    "data": ["views/project_task.xml"],
+    "data": ["data/res_config_data.xml", "views/project_task.xml"],
     "installable": True,
 }

--- a/project_parent_task_filter/data/res_config_data.xml
+++ b/project_parent_task_filter/data/res_config_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="project_config_settings" model="res.config.settings">
+            <field name="group_subtask_project" eval="True" />
+        </record>
+        <function model="res.config.settings" name="execute">
+            <value
+                model="res.config.settings"
+                search="[('id', '=', ref('project_config_settings'))]"
+            />
+        </function>
+    </data>
+</odoo>

--- a/project_parent_task_filter/readme/CONTRIBUTORS.rst
+++ b/project_parent_task_filter/readme/CONTRIBUTORS.rst
@@ -1,3 +1,5 @@
 * `C2i Change 2 improve <http://c2i.es/>`_:
 
   * Eduardo Magdalena <emagdalena@c2i.es>
+
+* Stephan Keller <MiStK@gmx.de>

--- a/project_parent_task_filter/readme/DESCRIPTION.rst
+++ b/project_parent_task_filter/readme/DESCRIPTION.rst
@@ -1,3 +1,4 @@
 This module adds a filter to show only the parent tasks in a project and
 a group to sort tasks by its parent tasks.
-It also add the subtask number in the kanban view.
+It also adds the subtask number in the kanban view and activates the use
+of subtasks in the project settings.

--- a/project_parent_task_filter/readme/ROADMAP.rst
+++ b/project_parent_task_filter/readme/ROADMAP.rst
@@ -1,2 +1,1 @@
-* Activate the configuration option to use subtasks
 * In Products of type Service add an option to create a subtask of an existing task

--- a/project_parent_task_filter/readme/USAGE.rst
+++ b/project_parent_task_filter/readme/USAGE.rst
@@ -1,3 +1,4 @@
 To use this module, you need to:
 
+#. Activate the subtasks for each project record individually
 #. Select the filter or the filter group Parent tasks in a Project

--- a/project_parent_task_filter/views/project_task.xml
+++ b/project_parent_task_filter/views/project_task.xml
@@ -28,6 +28,9 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.view_task_kanban" />
         <field name="arch" type="xml">
+            <kanban position="inside">
+                <field name="allow_subtasks" />
+            </kanban>
             <field name="color" position="after">
                 <field name="subtask_count" />
                 <field name="parent_id" />
@@ -39,7 +42,7 @@
                     style="margin-left: 10px;"
                 >
                     <t
-                        attrs="{'invisible': [('parent_id', '!=', False)]}"
+                        attrs="{'invisible': [('allow_subtasks', '=', False)]}"
                         groups="project.group_subtask_project"
                     >
                         <a


### PR DESCRIPTION
This PR: implements the following features:

1. automatically activation of project sub task project settings during addon installation (also removed the roadmap entry)
2. Add usage instructions that subtask usage must be activated for each project by the user
3. Optimize kanban view to avoid displaying subtask count for projects without subtask feature enabled

**Screenshot project kanban view grouped by project**

![KanbanGroupedByProject](https://user-images.githubusercontent.com/226753/98602959-8cca8280-22e1-11eb-8a88-a3e77fe31a4f.png)


**Screenshot of OCA runbot instance with activated sub tasks setting after installation**

![subtask_activatedV14](https://user-images.githubusercontent.com/226753/98604706-796ce680-22e4-11eb-9506-2b05225a48fc.png)
