### PR TITLE
[12.0][IMP] project_parent_task_filter: Activate subtasks on installation

### DIFF
--- a/project_parent_task_filter/__manifest__.py
+++ b/project_parent_task_filter/__manifest__.py
@@ -14,6 +14,7 @@
         "project",
     ],
     "data": [
+        "data/res_config_data.xml",
         "views/project_task.xml",
     ],
     "installable": True,

--- a/project_parent_task_filter/data/res_config_data.xml
+++ b/project_parent_task_filter/data/res_config_data.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="project_config_settings" model="res.config.settings">
+            <field name="group_subtask_project" eval="True" />
+        </record>
+        <function model="res.config.settings" name="execute">
+            <value 
+                model="res.config.settings"
+                search="[('id', '=', ref('project_config_settings'))]"
+            />
+        </function>
+    </data>
+</odoo>

--- a/project_parent_task_filter/readme/CONTRIBUTORS.rst
+++ b/project_parent_task_filter/readme/CONTRIBUTORS.rst
@@ -1,3 +1,5 @@
 * `C2i Change 2 improve <http://c2i.es/>`_:
 
   * Eduardo Magdalena <emagdalena@c2i.es>
+
+* Stephan Keller <MiStK@gmx.de>

--- a/project_parent_task_filter/readme/DESCRIPTION.rst
+++ b/project_parent_task_filter/readme/DESCRIPTION.rst
@@ -1,3 +1,4 @@
-This module adds a filter to show only the parent tasks in a project and 
+This module adds a filter to show only the parent tasks in a project and
 a group to sort tasks by its parent tasks.
-It also add the subtask number in the kanban view.
+It also adds the subtask number in the kanban view and activates the use
+of subtasks in the project settings.

--- a/project_parent_task_filter/readme/ROADMAP.rst
+++ b/project_parent_task_filter/readme/ROADMAP.rst
@@ -1,3 +1,2 @@
 * Rename the module name
-* Activate the configuration option to use subtasks
 * In Products of type Service add an option to create a subtask of an existing task


### PR DESCRIPTION
This PR automatically activates project sub task usage in project settings during addon installation.

Also removed the roadmap entry.
