### PR TITLE
[13.0][IMP] project_status: Add missing read_group test

### DIFF
--- a/project_status/tests/__init__.py
+++ b/project_status/tests/__init__.py
@@ -1,0 +1,3 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_project_status

--- a/project_status/tests/test_project_status.py
+++ b/project_status/tests/test_project_status.py
@@ -1,0 +1,13 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import common
+
+
+class TestProjectStatus(common.TransactionCase):
+    def setUp(self):
+        super().setUp()
+
+    def test_read_group_status_ids(self):
+        Project = self.env["project.project"]
+        grouped_projects = Project.read_group([], ["name"], ["project_status"])
+        self.assertEqual(len(grouped_projects), 4)


### PR DESCRIPTION
This PR is adding a test for project read_group. Used the same test style like in [project_milestone module](https://github.com/OCA/project/blob/fc9a5abfe1eb9aaf8a98994b5a9622c1279f5791/project_milestone/tests/test_project_milestone.py#L49)