### PR TITLE
[13.0][IMP] project_key: Allow copying of projects

### DIFF
--- a/project_key/__manifest__.py
+++ b/project_key/__manifest__.py
@@ -10,6 +10,6 @@
     "author": "Modoolar, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/project/",
     "depends": ["project"],
-    "data": ["views/project_key_views.xml"],
+    "data": ["data/ir_sequence_data.xml", "views/project_key_views.xml"],
     "post_init_hook": "post_init_hook",
 }

--- a/project_key/data/ir_sequence_data.xml
+++ b/project_key/data/ir_sequence_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <!-- Sequence for project copy key -->
+        <record id="seq_project_key" model="ir.sequence">
+            <field name="name">Project Copy Key sequence</field>
+            <field name="code">project.project.copy.key</field>
+            <field name="prefix">P</field>
+            <field name="padding">0</field>
+            <field name="company_id" eval="False" />
+        </record>
+    </data>
+</odoo>

--- a/project_key/models/project_project.py
+++ b/project_key/models/project_project.py
@@ -46,16 +46,27 @@ class Project(models.Model):
         if "key" in values:
             key = values["key"]
             update_key = self.key != key
-
+            old_prefix = self.task_key_sequence_id.prefix or ""
         res = super(Project, self).write(values)
 
-        if update_key:
+        if update_key or "name" in values:
             # Here we don't expect to have more than one record
             # because we can not have multiple projects with the same KEY.
             self.update_sequence()
-            self._update_task_keys()
+        if update_key:
+            self._update_task_keys(old_prefix)
 
         return res
+
+    def copy(self, default=None):
+        self.ensure_one()
+        if default is None:
+            default = {}
+        if "key" not in default:
+            default["key"] = self.env["ir.sequence"].next_by_code(
+                "project.project.copy.key"
+            )
+        return super().copy(default)
 
     def unlink(self):
         for project in self:
@@ -141,7 +152,7 @@ class Project(models.Model):
             key.append(item[:1].upper())
         return "".join(key)
 
-    def _update_task_keys(self):
+    def _update_task_keys(self, old_prefix=""):
         """
         This method will update task keys of the current project.
         """
@@ -151,7 +162,7 @@ class Project(models.Model):
         UPDATE project_task
         SET key = x.key
         FROM (
-          SELECT t.id, p.key || '-' || split_part(t.key, '-', 2) AS key
+          SELECT t.id, p.key || substr(t.key, %s) AS key
           FROM project_task t
           INNER JOIN project_project p ON t.project_id = p.id
           WHERE t.project_id = %s
@@ -159,7 +170,7 @@ class Project(models.Model):
         WHERE project_task.id = x.id;
         """
 
-        self.env.cr.execute(reindex_query, (self.id,))
+        self.env.cr.execute(reindex_query, (len(old_prefix), self.id,))
         self.env["project.task"].invalidate_cache(["key"], self.task_ids.ids)
 
     @api.model
@@ -177,5 +188,9 @@ class Project(models.Model):
             project.key = self.generate_project_key(project.name)
             project.create_sequence()
 
-            for task in project.task_ids:
+            for task in (
+                self.env["project.task"]
+                .with_context(active_test=False)
+                .search([("project_id", "=", project.id)])
+            ):
                 task.key = project.get_next_task_key()

--- a/project_key/tests/test_project.py
+++ b/project_key/tests/test_project.py
@@ -11,10 +11,10 @@ class TestProject(TestCommon):
         self.assertEqual(self.project_3.key, "PYT")
 
     def test_02_change_key(self):
-        self.project_1.key = "XXX"
+        self.project_1.key = "XX-X"
 
-        self.assertEqual(self.task11.key, "XXX-1")
-        self.assertEqual(self.task12.key, "XXX-2")
+        self.assertEqual(self.task11.key, "XX-X-1")
+        self.assertEqual(self.task12.key, "XX-X-2")
 
     def test_03_name_search(self):
 
@@ -62,3 +62,7 @@ class TestProject(TestCommon):
         project = self.Project.new({"name": "Software Development", "key": "TEST"})
         project._onchange_project_name()
         self.assertEqual(project.key, "TEST")
+
+    def test_10_copy_project_key_assign(self):
+        project_copy = self.project_1.copy()
+        self.assertNotEqual(self.project_1.key, project_copy.key)


### PR DESCRIPTION
1. Allow copying of projects (Add own sequence record `P1-PXXXXX`)
2. Fix updating task keys after changing project key containing `-` (replaced split_part by substring)
3. Fix updating sequence name after changing project name with existing project key


4. Fixing post_init_hook to set all project task keys (folded task_ids are ignored through domain see [here](https://github.com/odoo/odoo/blob/9241b92945edf695a534642b8ffe1977f9b32c8f/addons/project/models/project.py#L186))

**post_init_hook result before**

![project_key_hook_before_fix](https://user-images.githubusercontent.com/226753/99194046-60998080-277d-11eb-9b0e-6156ba5772de.png)



**post_init_hook result after fixing**

![project_key_hook_after_fix](https://user-images.githubusercontent.com/226753/99193899-27acdc00-277c-11eb-86e1-3444f882a84a.png)



 Fixes #734
