### PR TITLE
[FIX] project_task_code: If code column exists, the update process stop

### DIFF
--- a/project_task_code/hooks.py
+++ b/project_task_code/hooks.py
@@ -10,8 +10,10 @@ def pre_init_hook(cr):
     code constraint when the module is installed and before the post-init-hook
     is launched.
     """
-    cr.execute("ALTER TABLE project_task " "ADD COLUMN code character varying;")
-    cr.execute("UPDATE project_task " "SET code = id;")
+    cr.execute(
+        "ALTER TABLE project_task " "ADD COLUMN IF NOT EXISTS code character varying;"
+    )
+    cr.execute("UPDATE project_task " "SET code = id where code is null;")
 
 
 def post_init_hook(cr, registry):


### PR DESCRIPTION
init_hook should test if column code exist yet