### PR TITLE
[12.0][FIX] filter name `type_id` collides with the field of the same name

### DIFF
--- a/project_category/views/project_project_views.xml
+++ b/project_category/views/project_project_views.xml
@@ -9,7 +9,7 @@
                 <field name="type_id" string="Type"/>
             </field>
             <group expand="0">
-                <filter string="Type" name="type_id" help="Type" context="{'group_by':'type_id'}"/>
+                <filter string="Type" name="group_by_type_id" help="Type" context="{'group_by':'type_id'}"/>
             </group>
         </field>
     </record>


### PR DESCRIPTION
That's an issue when you try to set context with {'search_default_type_id': ...}