### PR TITLE
[13.0][IMP] project_timesheet_time_control: Get only base fields in wizard from account.analytic.line to prevent errors when custom fields exists

### DIFF
--- a/project_timesheet_time_control/wizards/hr_timesheet_switch.py
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch.py
@@ -135,7 +135,16 @@ class HrTimesheetSwitch(models.TransientModel):
             resuming_lines=self.ids, stop_dt=self.date_time,
         ).running_timer_id.button_end_work()
         # Start new timer
-        _fields = self.env["account.analytic.line"]._fields.keys()
+        _fields = (
+            self.env["ir.model.fields"]
+            .search(
+                [
+                    ("model_id.model", "=", "account.analytic.line"),
+                    ("state", "=", "base"),
+                ]
+            )
+            .mapped("name")
+        )
         self.read(_fields)
         values = self._convert_to_write(self._cache)
         new = self.env["account.analytic.line"].create(


### PR DESCRIPTION
Get only base fields in wizard from `account.analytic.line` to prevent errors when custom fields exists.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT29728