### PR TITLE
[14.0][IMP] project_key: Allow copying of projects

### DIFF
--- a/project_key/__manifest__.py
+++ b/project_key/__manifest__.py
@@ -10,7 +10,7 @@
     "author": "Modoolar, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/project",
     "depends": ["project"],
-    "data": ["views/project_key_views.xml"],
+    "data": ["data/ir_sequence_data.xml", "views/project_key_views.xml"],
     "post_init_hook": "post_init_hook",
     "external_dependencies": {
         "python": ["mock==3.0.5"],

--- a/project_key/data/ir_sequence_data.xml
+++ b/project_key/data/ir_sequence_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <data noupdate="1">
+        <!-- Sequence for project copy key -->
+        <record id="seq_project_key" model="ir.sequence">
+            <field name="name">Project Copy Key sequence</field>
+            <field name="code">project.project.copy.key</field>
+            <field name="prefix">P</field>
+            <field name="padding">0</field>
+            <field name="company_id" eval="False" />
+        </record>
+    </data>
+</odoo>

--- a/project_key/tests/test_project.py
+++ b/project_key/tests/test_project.py
@@ -11,10 +11,9 @@ class TestProject(TestCommon):
         self.assertEqual(self.project_3.key, "PYT")
 
     def test_02_change_key(self):
-        self.project_1.key = "XXX"
-
-        self.assertEqual(self.task11.key, "XXX-1")
-        self.assertEqual(self.task12.key, "XXX-2")
+        self.project_1.key = "XX-X"
+        self.assertEqual(self.task11.key, "XX-X-1")
+        self.assertEqual(self.task12.key, "XX-X-2")
 
     def test_03_name_search(self):
 
@@ -62,3 +61,7 @@ class TestProject(TestCommon):
         project = self.Project.new({"name": "Software Development", "key": "TEST"})
         project._onchange_project_name()
         self.assertEqual(project.key, "TEST")
+
+    def test_10_copy_project_key_assign(self):
+        project_copy = self.project_1.copy()
+        self.assertNotEqual(self.project_1.key, project_copy.key)


### PR DESCRIPTION
1. Allow copying of projects (Add own sequence record `P1-PXXXXX`)
2. Fix updating task keys after changing project key containing `-` (replaced split_part by substring)
3. Fix updating sequence name after changing project name with existing project key
4. Fixing post_init_hook to set all project task keys


Fixes #734
