### PR TITLE
[12.0] ADD project_timesheet_time_control_sale

### DIFF
--- a/project_timesheet_time_control_sale/__init__.py
+++ b/project_timesheet_time_control_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project_timesheet_time_control_sale/__manifest__.py
+++ b/project_timesheet_time_control_sale/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Lorenzo Battistini @ TAKOBI
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+{
+    "name": "Project timesheet time control - Sales Timesheet",
+    "summary": "Make 'Project timesheet time control' and 'Sales Timesheet' "
+               "work together",
+    "version": "12.0.1.0.0",
+    "development_status": "Beta",
+    "category": "Hidden",
+    "website": "https://github.com/OCA/project",
+    "author": "TAKOBI, Odoo Community Association (OCA)",
+    "maintainers": ["eLBati"],
+    "license": "AGPL-3",
+    "application": False,
+    "installable": True,
+    "auto_install": True,
+    "depends": [
+        "project_timesheet_time_control",
+        "sale_timesheet",
+    ],
+    "data": [
+    ],
+}

--- a/project_timesheet_time_control_sale/models/__init__.py
+++ b/project_timesheet_time_control_sale/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice

--- a/project_timesheet_time_control_sale/models/account_invoice.py
+++ b/project_timesheet_time_control_sale/models/account_invoice.py
@@ -1,0 +1,16 @@
+from odoo import models, api
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = "account.invoice.line"
+
+    @api.model
+    def _timesheet_domain_get_invoiced_lines(self, sale_line_delivery):
+        domain = super(AccountInvoiceLine, self)._timesheet_domain_get_invoiced_lines(
+            sale_line_delivery)
+        # invoice timesheet lines with duration
+        # (or without duration and without start date, thus not to be stopped)
+        return [
+            "&", "|", ("unit_amount", "!=", "0"),
+            "&", ("unit_amount", "=", "0"), ("date_time", "=", False)
+        ] + domain

--- a/project_timesheet_time_control_sale/readme/CONTRIBUTORS.rst
+++ b/project_timesheet_time_control_sale/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `TAKOBI <https://takobi.online>`_:
+
+  * Lorenzo Battistini

--- a/project_timesheet_time_control_sale/readme/DESCRIPTION.rst
+++ b/project_timesheet_time_control_sale/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+Make 'Project timesheet time control' and 'Sales Timesheet' work together.
+
+In particular, when trying to invoice timesheet lines which still have to be stopped.

--- a/setup/project_timesheet_time_control_sale/.eggs/README.txt
+++ b/setup/project_timesheet_time_control_sale/.eggs/README.txt
@@ -1,0 +1,6 @@
+This directory contains eggs that were downloaded by setuptools to build, test, and run plug-ins.
+
+This directory caches those eggs to prevent repeated downloads.
+
+However, it is safe to delete this directory.
+

--- a/setup/project_timesheet_time_control_sale/odoo/addons/project_timesheet_time_control_sale
+++ b/setup/project_timesheet_time_control_sale/odoo/addons/project_timesheet_time_control_sale
@@ -1,0 +1,1 @@
+../../../../project_timesheet_time_control_sale

--- a/setup/project_timesheet_time_control_sale/setup.py
+++ b/setup/project_timesheet_time_control_sale/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Make 'Project timesheet time control' and 'Sales Timesheet' work together.

In particular, when trying to invoice timesheet lines which still have to be stopped.