### PR TITLE
[14.0][FIX] Add custom embedded tree view in project.project for project.task.type

### DIFF
--- a/project_task_default_stage/views/project_view.xml
+++ b/project_task_default_stage/views/project_view.xml
@@ -27,7 +27,20 @@
         <field name="arch" type="xml">
             <xpath expr="//notebook" position="inside">
                 <page string="Project Stages" name="project_stages">
-                    <field name="type_ids" />
+                    <field name="type_ids">
+                        <tree>
+                            <field name="sequence" widget="handle" optional="show" />
+                            <field name="name" />
+                            <field name="fold" optional="show" />
+                            <field name="mail_template_id" optional="show" />
+                            <field name="rating_template_id" optional="show" />
+                            <field
+                                name="auto_validation_kanban_state"
+                                optional="hide"
+                            />
+                            <field name="description" optional="hide" />
+                        </tree>
+                    </field>
                 </page>
             </xpath>
         </field>


### PR DESCRIPTION
issue is that OCA module adds field type_ids inside project form without defining the view, so it select odoo default tree view for project.task.type which include project_ids in it:

![image (1)](https://user-images.githubusercontent.com/5673570/125935916-fe3c93a2-a80b-4240-86bb-e7c6ece74480.png)

By defining a custom embedded view, the problem is solved

Fixes : https://github.com/OCA/project/issues/836