### PR TITLE
[13.0][ADD] task dependency counter

### DIFF
--- a/project_task_dependency/__manifest__.py
+++ b/project_task_dependency/__manifest__.py
@@ -4,11 +4,11 @@
 
 {
     "name": "Project Task Dependencies",
-    "version": "13.0.1.0.1",
+    "version": "13.0.1.0.2",
     "category": "Project",
     "website": "https://github.com/OCA/project",
     "summary": "Enables to define dependencies (other tasks) of a task",
-    "author": "Onestein,Odoo Community Association (OCA)",
+    "author": "Janik von Rotz,Onestein,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": ["project"],
     "data": ["views/project_task_view.xml"],

--- a/project_task_dependency/models/project_task.py
+++ b/project_task_dependency/models/project_task.py
@@ -18,8 +18,7 @@ class ProjectTask(models.Model):
     )
 
     dependency_task_ids_count = fields.Integer(
-        string="Dependency Tasks Count",
-        compute="_compute_dependency_task_ids_count"
+        string="Dependency Tasks Count", compute="_compute_dependency_task_ids_count"
     )
 
     recursive_dependency_task_ids = fields.Many2many(
@@ -97,13 +96,12 @@ class ProjectTask(models.Model):
             )
         return res
 
-
     def view_dependency_task_ids(self):
         self.ensure_one()
         return {
-            'type': 'ir.actions.act_window',
-            'name': 'Dependencies',
-            'view_mode': 'kanban,form',
-            'res_model': 'project.task',
-            'domain': [('id', 'in',  [t.id for t in self.dependency_task_ids])]
+            "type": "ir.actions.act_window",
+            "name": "Dependencies",
+            "view_mode": "kanban,form",
+            "res_model": "project.task",
+            "domain": [("id", "in", [t.id for t in self.dependency_task_ids])],
         }

--- a/project_task_dependency/readme/CONTRIBUTORS.rst
+++ b/project_task_dependency/readme/CONTRIBUTORS.rst
@@ -2,6 +2,7 @@
 * Andrea Stirpe <a.stirpe@onestein.nl>
 * Adria Gil Sorribes <adria.gil@forgeflow.com>
 * Pedro M. Baeza <pedro.baeza@tecnativa.com>
+* Janik von rotz <janik.vonrotz@mint-syste.ch>
 * `Tecnativa <https://www.tecnativa.com>` _:
 
   * Manuel Calero

--- a/project_task_dependency/views/project_task_view.xml
+++ b/project_task_dependency/views/project_task_view.xml
@@ -22,6 +22,11 @@
                     </field>
                 </page>
             </xpath>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <button name="view_dependency_task_ids" type="object" class="oe_stat_button" icon="fa-tasks" attrs="{'invisible' : [('dependency_task_ids_count', '=', 0)]}">
+                    <field string="Dependencies" name="dependency_task_ids_count" widget="statinfo"/>
+                </button>
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/project_task_dependency/views/project_task_view.xml
+++ b/project_task_dependency/views/project_task_view.xml
@@ -23,8 +23,18 @@
                 </page>
             </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button name="view_dependency_task_ids" type="object" class="oe_stat_button" icon="fa-tasks" attrs="{'invisible' : [('dependency_task_ids_count', '=', 0)]}">
-                    <field string="Dependencies" name="dependency_task_ids_count" widget="statinfo"/>
+                <button
+                    name="view_dependency_task_ids"
+                    type="object"
+                    class="oe_stat_button"
+                    icon="fa-tasks"
+                    attrs="{'invisible' : [('dependency_task_ids_count', '=', 0)]}"
+                >
+                    <field
+                        string="Dependencies"
+                        name="dependency_task_ids_count"
+                        widget="statinfo"
+                    />
                 </button>
             </xpath>
         </field>


### PR DESCRIPTION
Clicking on the dependency list opens popup. This is annoying and also when opening a task you cannot see right away if there are dependencies. The smart button should fix this. Not sure if the open action is best practice.