### PR TITLE
[IMP] project_timeline: restore date_start field

### DIFF
--- a/project_timeline/views/project_task_view.xml
+++ b/project_timeline/views/project_task_view.xml
@@ -66,6 +66,7 @@
         <field name="inherit_id" ref="project.view_task_form2" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='date_assign']" position="after">
+                <field name="date_start" />
                 <field name="date_end" />
             </xpath>
         </field>


### PR DESCRIPTION
Thanks to these two typos: 

https://github.com/OCA/project/commit/964a5c05bd76ad640beaaa19d49384ca7459f545#diff-f2f81dcbaa2dc0db56e12f2ca784d921c1acbd33e73500563c4c07a455808fc2R69

and

https://github.com/OCA/project/commit/9f92ea41f4a77ed54bc6025c22de9b469db56e80#diff-f2f81dcbaa2dc0db56e12f2ca784d921c1acbd33e73500563c4c07a455808fc2R68

this field disappear from task form.