### PR TITLE
[12.0][IMP] project_task_code: Added a migration script that will 'uniqify'…

### DIFF
--- a/project_task_code/migrations/12.0.1.1/pre-migration.py
+++ b/project_task_code/migrations/12.0.1.1/pre-migration.py
@@ -16,7 +16,7 @@ def uniqify_codes(env):
             env.cr.execute("SELECT id FROM project_task WHERE code = %s",
                 [task_code])
         else:
-            env.cr.execute("SELECT id FROM project_task"
+            env.cr.execute("SELECT id FROM project_task "
                            "WHERE code IS NULL OR code = '/'")
         similar_task_ids = [x['id'] for x in env.cr.dictfetchall()]
 

--- a/project_task_code/migrations/12.0.1.1/pre-migration.py
+++ b/project_task_code/migrations/12.0.1.1/pre-migration.py
@@ -14,7 +14,7 @@ def uniqify_codes(env):
 
         if not code_is_null:
             env.cr.execute("SELECT id FROM project_task WHERE code = %s",
-                [task_code])
+                           [task_code])
         else:
             env.cr.execute("SELECT id FROM project_task "
                            "WHERE code IS NULL OR code = '/'")

--- a/project_task_code/migrations/12.0.1.1/pre-migration.py
+++ b/project_task_code/migrations/12.0.1.1/pre-migration.py
@@ -10,20 +10,27 @@ def uniqify_codes(env):
     env.cr.execute("SELECT DISTINCT(code) FROM project_task")
     for row in env.cr.dictfetchall():
         task_code = row['code']
+        code_is_null = not task_code or task_code == '/'
 
-        if task_code or task_code == '/':
-            env.cr.execute("SELECT id FROM project_task WHERE code = %s", [task_code])
+        if not code_is_null:
+            env.cr.execute("SELECT id FROM project_task WHERE code = %s",
+                [task_code])
         else:
-            env.cr.execute("SELECT id FROM project_task WHERE code IS NULL")
+            env.cr.execute("SELECT id FROM project_task"
+                           "WHERE code IS NULL OR code = '/'")
         similar_task_ids = [x['id'] for x in env.cr.dictfetchall()]
 
-        # Only change the tasks that are not the first of its kind
-        lowest_task_id = min(similar_task_ids)
+        # Only change the tasks that are not the first of its kind and
+        # not with code NULL.
+        preserved_task_id = min(similar_task_ids) if not code_is_null else -1
         for similar_task_id in similar_task_ids:
-            if similar_task_id > lowest_task_id:
+            if similar_task_id > preserved_task_id:
                 new_code = env['ir.sequence'].next_by_code('project.task')
 
-                env.cr.execute("UPDATE project_task SET code = %s WHERE id = %s", [new_code, similar_task_id])
+                env.cr.execute(
+                    "UPDATE project_task SET code = %s WHERE id = %s",
+                    [new_code, similar_task_id]
+                )
 
 
 @openupgrade.migrate()

--- a/project_task_code/migrations/12.0.1.1/pre-migration.py
+++ b/project_task_code/migrations/12.0.1.1/pre-migration.py
@@ -1,0 +1,31 @@
+# Copyright 2021 Therp B.V.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def uniqify_codes(env):
+    """Gives all tasks of which the `code` field is not unique, a new
+       (unique) value.
+    """
+    env.cr.execute("SELECT DISTINCT(code) FROM project_task")
+    for row in env.cr.dictfetchall():
+        task_code = row['code']
+
+        if task_code or task_code == '/':
+            env.cr.execute("SELECT id FROM project_task WHERE code = %s", [task_code])
+        else:
+            env.cr.execute("SELECT id FROM project_task WHERE code IS NULL")
+        similar_task_ids = [x['id'] for x in env.cr.dictfetchall()]
+
+        # Only change the tasks that are not the first of its kind
+        lowest_task_id = min(similar_task_ids)
+        for similar_task_id in similar_task_ids:
+            if similar_task_id > lowest_task_id:
+                new_code = env['ir.sequence'].next_by_code('project.task')
+
+                env.cr.execute("UPDATE project_task SET code = %s WHERE id = %s", [new_code, similar_task_id])
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    uniqify_codes(env)


### PR DESCRIPTION
… the task codes, so that the new unique constraint can be applied without issues.

In 12.0, the project_task_code module adds a unique constraint to its code field that hasn't been unique before. This of course causes an issue when, for whatever reason, the DB contains 'duplicates', and you are migrating your database. I don't expect there to be a lot of duplicate task codes if nobody has messed with them manually, yet it can happen. However, empty task codes (with a value of NULL), _can_ be expected.
In either case, the duplicates get assigned a new task code.

The `pre_init_hook` does something similar, but does not handle duplicate codes that are not NULL.