### PR TITLE
[IMP] [12.0] project_timeline : change task display in timeline view.

### DIFF
--- a/project_timeline/views/project_task_view.xml
+++ b/project_timeline/views/project_task_view.xml
@@ -14,7 +14,7 @@
                       date_stop="date_end"
                       default_group_by="project_id"
                       event_open_popup="true"
-                      colors="#ec7063: user_id == false; #2ecb71: kanban_state == 'done';">
+                      colors="white: user_id == false; #2ecb71: kanban_state == 'done'; #ec7063: kanban_state == 'blocked'">
                 <field name="user_id"/>
                 <field name="planned_hours"/>
                 <templates>
@@ -26,7 +26,7 @@
                             <span name="display_name">
                                 <t t-esc="record.display_name"/>
                             </span>
-                            <small name="planned_hours" class="text-muted ml4">
+                            <small name="planned_hours" class="text-muted ml4" t-if="record.planned_hours">
                                 <t t-esc="field_utils.format.float_time(record.planned_hours)"/>
                             </small>
                         </div>


### PR DESCRIPTION
Hi.

proposing a minor change in ``project_timeline``.

First : Thanks a lot for all that great work ! I just discovered this module and it is really "ready to use". Thanks to Tecnativa and Onestein team !

**Before that PR**

- on timeline view, the task are green if ``kanban_state == done``. (consistent) but red if user is not set. no color is defined if ``kanban_state == blocked``, that is annoying because it is an important point.

**After that PR**
 
- consistency of tasks colors regarding ``kanban_state`` : blocked tasks are red and task without user are white. (This point is also visible because no face are displayed on the task)

![image](https://user-images.githubusercontent.com/3407482/149547064-1065aa7b-ee72-4554-b404-767a43b2920d.png)


- planned_hours is displayed only if not null saving space. (before, all the task finish by ``00:00`` if no planned_hours is set).