### PR TITLE
[IMP] project_task_project_required : project field mandatory by default

### DIFF
--- a/project_task_project_required/__manifest__.py
+++ b/project_task_project_required/__manifest__.py
@@ -19,4 +19,7 @@
         'views/project_task.xml',
         'views/res_config_settings.xml',
     ],
+    'demo': [
+        'demo/res_company.xml',
+    ],
 }

--- a/project_task_project_required/demo/res_company.xml
+++ b/project_task_project_required/demo/res_company.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2022 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+	<!-- Disable the feature on the demo company
+	to avoid error with other modules, when loading demo tasks
+	or executing tests -->
+    <record id="base.main_company" model="res.company">
+        <field name="is_project_task_project_required" eval="False"/>
+    </record>
+
+</odoo>

--- a/project_task_project_required/models/res_company.py
+++ b/project_task_project_required/models/res_company.py
@@ -9,4 +9,5 @@ class ResCompany(models.Model):
 
     is_project_task_project_required = fields.Boolean(
         string='Require Projects on Tasks',
+        default=True,
     )

--- a/project_task_project_required/readme/CONFIGURE.rst
+++ b/project_task_project_required/readme/CONFIGURE.rst
@@ -1,4 +1,7 @@
-To make project selection mandatory on task:
+By installing this module, the project field
+will be mandatory for all the companies.
+
+To make project selection optional on task for a given company:
 
 # Go to *Project > Configuration > Settings*
-# Make task selection mandatory for new tasks by checking *Require Projects on Tasks*
+# Uncheck *Require Projects on Tasks*


### PR DESCRIPTION
Change the default behaviour of ``project_task_project_required`` for new companies (or during installation).

the feature is now active by default.

**Rational**
 
- most of the odoo instances are mono-company. In that case, if we install this module, the expected behaviour is to have the feature enabled.
- for multi company instances, we can assume that if we install this module, we also want the feature enabled

**Impact**
- reduce configuration time.

CC : author : @alexey-pelykh