### PR TITLE
[FIX] project_timeline remove task view mode

### DIFF
--- a/project_timeline/views/project_task_view.xml
+++ b/project_timeline/views/project_task_view.xml
@@ -77,7 +77,7 @@
     <record id="project.action_view_all_task" model="ir.actions.act_window">
         <field
             name="view_mode"
-        >tree,kanban,form,calendar,timeline,pivot,graph,gantt,activity,map</field>
+        >tree,kanban,form,calendar,timeline,pivot,graph,activity</field>
     </record>
     <record
         id="project.action_view_task_overpassed_draft"


### PR DESCRIPTION
Modules that bring `gantt` and `map` view mode are not declared in module dependency
Those modes were introduced by https://github.com/OCA/project/pull/869/files#r785447743