### PR TITLE
[12.0][FIX] project_purchase_link: get only purchase invoices

### DIFF
--- a/project_purchase_link/models/project_project.py
+++ b/project_purchase_link/models/project_project.py
@@ -39,7 +39,8 @@ class ProjectProject(models.Model):
         for project in self:
             groups = self.env['account.invoice.line'].read_group(
                 [('account_analytic_id', '=', project.analytic_account_id.id),
-                 ('invoice_id.state', '!=', 'cancel')],
+                 ('invoice_id.state', '!=', 'cancel'),
+                 ('invoice_id.type', 'in', ['in_invoice', 'in_refund'])],
                 ['price_subtotal'],
                 ['invoice_id'])
             purchase_invoice_line_total = 0
@@ -84,7 +85,9 @@ class ProjectProject(models.Model):
         action_dict = action.read()[0] if action else {}
         lines = self.env['account.invoice.line'].search([
             ('account_analytic_id', 'in',
-             self.mapped('analytic_account_id').ids)])
+             self.mapped('analytic_account_id').ids),
+            ('invoice_id.state', '!=', 'cancel'),
+            ('invoice_id.type', 'in', ['in_invoice', 'in_refund'])])
         domain = expression.AND([
             [('id', 'in', lines.mapped('invoice_id').ids)],
             safe_eval(action.domain or '[]')])
@@ -95,7 +98,9 @@ class ProjectProject(models.Model):
     def button_open_purchase_invoice_line(self):
         self.ensure_one()
         domain = [('account_analytic_id', 'in',
-                   self.mapped('analytic_account_id').ids)]
+                   self.mapped('analytic_account_id').ids),
+                  ('invoice_id.state', '!=', 'cancel'),
+                  ('invoice_id.type', 'in', ['in_invoice', 'in_refund'])]
         return {
             'name': _('Purchase Invoice Lines'),
             'domain': domain,

--- a/project_purchase_link/tests/test_project_purchase_link.py
+++ b/project_purchase_link/tests/test_project_purchase_link.py
@@ -70,4 +70,7 @@ class TestProjectPurchaseUtilities(common.SavepointCase):
         invoice_dict = self.project.button_open_purchase_invoice()
         self.assertEquals(invoice_dict.get('domain'), invoice_domain)
         invoice_line_dict = self.project.button_open_purchase_invoice_line()
+        purchase_domain.append(('invoice_id.state', '!=', 'cancel'))
+        purchase_domain.append(('invoice_id.type', 'in',
+                                ['in_invoice', 'in_refund']))
         self.assertEquals(invoice_line_dict.get('domain'), purchase_domain)


### PR DESCRIPTION
Both the information on the buttons, and their domains, are corrected so that you only get purchase invoices.