### PR TITLE
[13.0][IMP] project_purchase_link: FR Translation + improve button action

### DIFF
--- a/project_purchase_link/i18n/fr.po
+++ b/project_purchase_link/i18n/fr.po
@@ -1,0 +1,71 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* project_purchase_link
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 13.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-03-01 13:06+0000\n"
+"PO-Revision-Date: 2022-03-01 13:06+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: project_purchase_link
+#: model:ir.model.fields,field_description:project_purchase_link.field_project_project__purchase_count
+msgid "# Purchase"
+msgstr "# Achat"
+
+#. module: project_purchase_link
+#: model:ir.model.fields,field_description:project_purchase_link.field_project_project__purchase_invoice_count
+msgid "# Purchase Invoice"
+msgstr "# Facture achat"
+
+#. module: project_purchase_link
+#: model:ir.model,name:project_purchase_link.model_project_project
+msgid "Project"
+msgstr "Dossier client"
+
+#. module: project_purchase_link
+#: code:addons/project_purchase_link/models/project_project.py:0
+#, python-format
+msgid "Purchase Invoice Lines"
+msgstr "Lignes factures achats"
+
+#. module: project_purchase_link
+#: model:ir.model.fields,field_description:project_purchase_link.field_project_project__purchase_invoice_line_total
+#: model_terms:ir.ui.view,arch_db:project_purchase_link.project_project_view_form
+msgid "Purchase Invoice Total"
+msgstr "Lignes factures achats"
+
+#. module: project_purchase_link
+#: model_terms:ir.ui.view,arch_db:project_purchase_link.project_project_view_form
+msgid "Purchase Invoices"
+msgstr "Factures achats"
+
+#. module: project_purchase_link
+#: code:addons/project_purchase_link/models/project_project.py:0
+#, python-format
+msgid "Purchase Order"
+msgstr "Commande fournisseur"
+
+#. module: project_purchase_link
+#: code:addons/project_purchase_link/models/project_project.py:0
+#, python-format
+msgid "Purchase Order Lines"
+msgstr "Lignes commandes achats"
+
+#. module: project_purchase_link
+#: model:ir.model.fields,field_description:project_purchase_link.field_project_project__purchase_line_total
+#: model_terms:ir.ui.view,arch_db:project_purchase_link.project_project_view_form
+msgid "Purchase Total"
+msgstr "Lignes commandes achats"
+
+#. module: project_purchase_link
+#: model_terms:ir.ui.view,arch_db:project_purchase_link.project_project_view_form
+msgid "Purchases"
+msgstr "Commandes achats"


### PR DESCRIPTION
The action to display purchase invoices lines return every invoice lines, even related to customer invoices.
But it should be only related to purchases (type is `in_invoice`)