### PR TITLE
[13.0][IMP] project_stock: Confirm the new stock movements in the "Check availability materials" button

### DIFF
--- a/project_stock/models/project_task.py
+++ b/project_stock/models/project_task.py
@@ -118,10 +118,10 @@ class Task(models.Model):
         return {"name": values["name"]}
 
     def action_confirm(self):
-        self.mapped("move_ids").write({"state": "confirmed"})
-        self.action_assign()
+        self.mapped("move_ids")._action_confirm()
 
     def action_assign(self):
+        self.action_confirm()
         self.mapped("move_ids")._action_assign()
 
     def button_scrap(self):
@@ -187,7 +187,7 @@ class Task(models.Model):
             stage = self.env["project.task.type"].browse(vals.get("stage_id"))
             if stage.done_stock_moves:
                 # Avoid permissions error if the user does not have access to stock.
-                self.sudo().action_confirm()
+                self.sudo().action_assign()
         return res
 
     def unlink(self):

--- a/project_stock/tests/common.py
+++ b/project_stock/tests/common.py
@@ -14,6 +14,9 @@ class TestProjectStockBase(common.SavepointCase):
         cls.product_b = cls.env["product.product"].create(
             {"name": "Test product B", "standard_price": 20}
         )
+        cls.product_c = cls.env["product.product"].create(
+            {"name": "Test product C", "standard_price": 0}
+        )
         warehouse = cls.env["stock.warehouse"].search(
             [("company_id", "=", cls.env.company.id)], limit=1
         )


### PR DESCRIPTION
Confirm the new stock movements in the "**Check availability materials**" button (if movements have been added after confirming the materials).

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT35602