### PR TITLE
[FIX][project_sequence_task] Share project task code sequence over companies

### DIFF
--- a/project_task_code/data/task_sequence.xml
+++ b/project_task_code/data/task_sequence.xml
@@ -8,5 +8,6 @@
         <field name="code">project.task</field>
         <field eval="4" name="padding" />
         <field name="prefix">T</field>
+        <field name="company_id" eval="False" />
     </record>
 </odoo>


### PR DESCRIPTION

While creating a new company a new project is created with 2 tasks by
the `hr_timesheet._create_internal_project_task` method.

Without sequence available on all companies, tasks can't be created and will raise an exception as
code will be null.

Seen in unit-test ([Travis failing job](https://app.travis-ci.com/github/OCA/project/jobs/569404375))
while developed PR #814.