### PR TITLE
[14.0] [IMP] Allow set duration on timesheet time control

### DIFF
--- a/project_timesheet_time_control/wizards/hr_timesheet_switch_view.xml
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch_view.xml
@@ -19,6 +19,13 @@
             <field name="unit_amount" position="attributes">
                 <attribute name="invisible">1</attribute>
             </field>
+            <field name="project_id" position="before">
+                <field
+                    name="unit_amount"
+                    widget="timesheet_uom"
+                    decoration-danger="unit_amount &gt; 24"
+                />
+            </field>
             <xpath expr="//sheet/group/group" position="attributes">
                 <attribute name="colspan">4</attribute>
             </xpath>


### PR DESCRIPTION
Previous this improvement when user launch wizard to "Start work", user can set "Start Time" and optionally "End Time".

If user set "End Time" an timesheet line is created with computed duration.

With this PR user can set "Start Time" and "Duration".

If user usually create thimesheet line with duration instead of start/stop, this way es quickly than edit task, create new line and save task.