### PR TITLE
[13.0][FIX+IMP] project_stock: Prevent merge moves + Show buttons when they are really needed..

### DIFF
--- a/project_stock/__manifest__.py
+++ b/project_stock/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 {
     "name": "Project Stock",
-    "version": "13.0.1.1.2",
+    "version": "13.0.2.0.0",
     "category": "Project Management",
     "website": "https://github.com/OCA/project",
     "author": "Tecnativa, Odoo Community Association (OCA)",

--- a/project_stock/migrations/13.0.2.0.0/post-migration.py
+++ b/project_stock/migrations/13.0.2.0.0/post-migration.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    pg_model = env["procurement.group"]
+    for task in env["project.task"].search([("move_ids", "!=", False)]):
+        group = pg_model.create({task._prepare_procurement_group_vals()})
+        task.write({"group_id": group.id})
+        task.move_ids.write({"group_id": group.id})

--- a/project_stock/models/project_task.py
+++ b/project_stock/models/project_task.py
@@ -79,6 +79,7 @@ class Task(models.Model):
         inverse_name="stock_task_id",
         string="Analytic Lines",
     )
+    group_id = fields.Many2one(comodel_name="procurement.group",)
 
     def _compute_scrap_move_count(self):
         data = self.env["stock.scrap"].read_group(
@@ -151,8 +152,8 @@ class Task(models.Model):
         self.action_assign()
 
     @api.model
-    def _prepare_procurement_group_vals(self, values):
-        return {"name": values["name"]}
+    def _prepare_procurement_group_vals(self):
+        return {"name": "Task-ID: %s" % self.id}
 
     def action_confirm(self):
         self.mapped("move_ids")._action_confirm()

--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -83,8 +83,13 @@ class StockMove(models.Model):
             task = self.env["project.task"].browse(
                 self.env.context.get("default_raw_material_task_id")
             )
+            if not task.group_id:
+                task.group_id = self.env["procurement.group"].create(
+                    task._prepare_procurement_group_vals()
+                )
             defaults.update(
                 {
+                    "group_id": task.group_id.id,
                     "location_id": (
                         task.location_id.id or task.project_id.location_id.id
                     ),

--- a/project_stock/tests/common.py
+++ b/project_stock/tests/common.py
@@ -88,6 +88,8 @@ class TestProjectStockBase(common.SavepointCase):
             self.env["project.task"].with_context(self._prepare_context_task(self))
         )
         task_form.name = "Test task"
+        # Save task to use default_get() correctlly in stock.moves
+        task_form.save()
         for product in products:
             with task_form.move_ids.new() as move_form:
                 move_form.product_id = product[0]

--- a/project_stock/tests/test_project_stock.py
+++ b/project_stock/tests/test_project_stock.py
@@ -18,15 +18,18 @@ class TestProjectStock(TestProjectStockBase):
         )
 
     def test_project_task_misc(self):
+        self.assertTrue(self.task.group_id)
         self.assertEqual(self.task.picking_type_id, self.picking_type)
         self.assertEqual(self.task.location_id, self.location)
         self.assertEqual(self.task.location_dest_id, self.location_dest)
         self.assertEqual(self.move_product_a.name, self.task.name)
+        self.assertEqual(self.move_product_a.group_id, self.task.group_id)
         self.assertEqual(self.move_product_a.reference, self.task.name)
         self.assertEqual(self.move_product_a.location_id, self.location)
         self.assertEqual(self.move_product_a.location_dest_id, self.location_dest)
         self.assertEqual(self.move_product_a.picking_type_id, self.picking_type)
         self.assertEqual(self.move_product_a.raw_material_task_id, self.task)
+        self.assertEqual(self.move_product_b.group_id, self.task.group_id)
         self.assertEqual(self.move_product_b.location_id, self.location)
         self.assertEqual(self.move_product_b.location_dest_id, self.location_dest)
         self.assertEqual(self.move_product_b.picking_type_id, self.picking_type)
@@ -94,6 +97,7 @@ class TestProjectStock(TestProjectStockBase):
         move_product_c = self.task.move_ids.filtered(
             lambda x: x.product_id == self.product_c
         )
+        self.assertEqual(move_product_c.group_id, self.task.group_id)
         self.assertEqual(move_product_c.state, "draft")
         self.task.action_assign()
         self.assertEqual(move_product_c.state, "assigned")

--- a/project_stock/views/project_task_view.xml
+++ b/project_stock/views/project_task_view.xml
@@ -44,14 +44,14 @@
                     string="Confirm materials"
                     type="object"
                     class="oe_highlight"
-                    attrs="{'invisible':['|','|',('stock_state', '!=', 'pending'),('done_stock_moves', '=', False),('stock_moves_is_locked','=',False)]}"
+                    attrs="{'invisible':[('allow_moves_action_confirm','=',False)]}"
                 />
                 <button
                     name="action_assign"
                     string="Check availability materials"
                     type="object"
                     class="oe_highlight"
-                    attrs="{'invisible':['|', ('stock_state', '!=', 'confirmed'),('stock_moves_is_locked','=',False)]}"
+                    attrs="{'invisible':[('allow_moves_action_assign','=',False)]}"
                 />
                 <button
                     name="button_scrap"
@@ -104,6 +104,8 @@
                     <field name="done_stock_moves" invisible="1" />
                     <field name="stock_moves_is_locked" invisible="1" />
                     <field name="stock_state" invisible="1" />
+                    <field name="allow_moves_action_confirm" invisible="1" />
+                    <field name="allow_moves_action_assign" invisible="1" />
                     <field name="unreserve_visible" invisible="1" />
                     <field
                         name="move_ids"


### PR DESCRIPTION
Changes done:
- [x] Auto-create procurement.group in task to use it in moves to prevent merge moves from another tasks.
- [x] Show buttons when they are really needed. 

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT37708