### PR TITLE
[15.0][FIX] project_milestone: fixed migration scripts. 

### DIFF
--- a/project_milestone/migrations/15.0.1.0.0/pre-migration.py
+++ b/project_milestone/migrations/15.0.1.0.0/pre-migration.py
@@ -3,11 +3,11 @@ from openupgradelib import openupgrade
 namespec = [("project_milestone", "project_task_milestone")]
 
 field_spec = [
-    ("project", "project_milestone", "target_date", "deadline"),
+    ("project.milestone", "project_milestone", "target_date", "deadline"),
 ]
 
 
 @openupgrade.migrate()
-def migrate(cr, env, version):
-    openupgrade.update_module_names(cr, namespec, False)
-    openupgrade.rename_fields(cr, field_spec, False)
+def migrate(env, version):
+    openupgrade.update_module_names(env.cr, namespec, False)
+    openupgrade.rename_fields(env, field_spec, False)


### PR DESCRIPTION
In migrate function there was cr left, changed that. Also in rename_fields was left cr, where was needed an env.