### PR TITLE
[14.0][FIX] project_mail_chatter: We need to replace oe_chatter div to place it after the sheet and show as expected.

### DIFF
--- a/project_mail_chatter/README.rst
+++ b/project_mail_chatter/README.rst
@@ -32,6 +32,11 @@ Add message chatter on the Project form.
 .. contents::
    :local:
 
+Known issues / Roadmap
+======================
+
+This module is not needed in v15 because odoo core has already added the messaging in project.
+
 Bug Tracker
 ===========
 

--- a/project_mail_chatter/readme/ROADMAP.rst
+++ b/project_mail_chatter/readme/ROADMAP.rst
@@ -1,0 +1,1 @@
+This module is not needed in v15 because odoo core has already added the messaging in project.

--- a/project_mail_chatter/static/description/index.html
+++ b/project_mail_chatter/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Project Mail Chatter</title>
 <style type="text/css">
 
@@ -372,18 +372,23 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="id1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="id2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="id3">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="id4">Contributors</a></li>
-<li><a class="reference internal" href="#other-credits" id="id5">Other credits</a></li>
-<li><a class="reference internal" href="#maintainers" id="id6">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="id1">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="id2">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="id3">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="id4">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="id5">Contributors</a></li>
+<li><a class="reference internal" href="#other-credits" id="id6">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="id7">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#id1">Known issues / Roadmap</a></h1>
+<p>This module is not needed in v15 because odoo core has already added the messaging in project.</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#id1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#id2">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/project/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us smashing it by providing a detailed and welcomed
@@ -391,27 +396,27 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#id2">Credits</a></h1>
+<h1><a class="toc-backref" href="#id3">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#id3">Authors</a></h2>
+<h2><a class="toc-backref" href="#id4">Authors</a></h2>
 <ul class="simple">
 <li>Open Source Integrators</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#id4">Contributors</a></h2>
+<h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
 <li>Ammar Officewala &lt;<a class="reference external" href="mailto:ammar.o.serpentcs&#64;gmail.com">ammar.o.serpentcs&#64;gmail.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="other-credits">
-<h2><a class="toc-backref" href="#id5">Other credits</a></h2>
+<h2><a class="toc-backref" href="#id6">Other credits</a></h2>
 <ul class="simple">
 <li>Open Source Integrators &lt;<a class="reference external" href="mailto:contact&#64;opensourceintegrators.com">contact&#64;opensourceintegrators.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#id6">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#id7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose

--- a/project_mail_chatter/views/project_view.xml
+++ b/project_mail_chatter/views/project_view.xml
@@ -4,11 +4,22 @@
         <field name="name">Project description</field>
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project" />
+        <field name="priority">99</field>
         <field name="arch" type="xml">
-            <field name="message_follower_ids" position="after">
-                <field name="activity_ids" />
-                <field name="message_ids" />
-            </field>
+            <!-- We need to replace oe_chatter div to place it after the sheet and show as expected. !-->
+            <xpath expr="//div[hasclass('oe_chatter')]" position="replace" />
+            <sheet position="after">
+                <div class="oe_chatter">
+                    <field
+                        name="message_follower_ids"
+                        options="{'post_refresh':True}"
+                        help="Follow this project to automatically track the events associated to tasks and issues of this project."
+                        groups="base.group_user"
+                    />
+                    <field name="activity_ids" />
+                    <field name="message_ids" />
+                </div>
+            </sheet>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
We need to replace `oe_chatter` div to place it after the sheet and show as expected.

Before
![project_mail_chatter-antes](https://user-images.githubusercontent.com/4117568/183441297-35dd5fd8-13af-4b6e-aac7-225a5a6c21c1.png)

After
![project_mail_chatter-despues](https://user-images.githubusercontent.com/4117568/183441322-334227e9-8de9-4867-b149-effbde1de948.png)


Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38498