### PR TITLE
[15.0][IMP] project_forecast_line_holidays_public: Add a setting `Recompute forecast lines immediately`

### DIFF
--- a/project_forecast_line_holidays_public/__manifest__.py
+++ b/project_forecast_line_holidays_public/__manifest__.py
@@ -9,6 +9,7 @@
     "category": "Project",
     "website": "https://github.com/OCA/project",
     "depends": ["project_forecast_line", "hr_holidays_public"],
-    "data": [],
+    "data": ["views/res_config_settings_views.xml"],
+    "development_status": "Alpha",
     "installable": True,
 }

--- a/project_forecast_line_holidays_public/i18n/fr.po
+++ b/project_forecast_line_holidays_public/i18n/fr.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-09 12:34+0000\n"
+"POT-Creation-Date: 2022-09-12 09:37+0000\n"
 "PO-Revision-Date: 2021-09-10 14:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,13 +17,50 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: project_forecast_line_holidays_public
+#: model_terms:ir.ui.view,arch_db:project_forecast_line_holidays_public.res_config_settings_view_form
+msgid ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
+"specific.\" aria-label=\"Values set here are company-specific.\" groups="
+"\"base.group_multi_company\" role=\"img\"/>"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
+#: model:ir.model,name:project_forecast_line_holidays_public.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
+#: model_terms:ir.ui.view,arch_db:project_forecast_line_holidays_public.res_config_settings_view_form
+msgid "Compute forecast on public holidays creation"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
+#: model:ir.model,name:project_forecast_line_holidays_public.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
 #: model:ir.model,name:project_forecast_line_holidays_public.model_forecast_line
 msgid "Forecast"
 msgstr ""
 
 #. module: project_forecast_line_holidays_public
+#: model:ir.model.fields,help:project_forecast_line_holidays_public.field_res_company__immediate_compute_forecast_line
+#: model:ir.model.fields,help:project_forecast_line_holidays_public.field_res_config_settings__immediate_compute_forecast_line
+msgid ""
+"If checked will force forecast lines recomputation on public holidays "
+"creation."
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
 #: model:ir.model,name:project_forecast_line_holidays_public.model_hr_holidays_public_line
 msgid "Public Holidays Lines"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
+#: model:ir.model.fields,field_description:project_forecast_line_holidays_public.field_res_company__immediate_compute_forecast_line
+#: model:ir.model.fields,field_description:project_forecast_line_holidays_public.field_res_config_settings__immediate_compute_forecast_line
+msgid "Recompute forecast lines immediately"
 msgstr ""
 
 #~ msgid "Display Name"

--- a/project_forecast_line_holidays_public/i18n/project_forecast_line_holidays_public.pot
+++ b/project_forecast_line_holidays_public/i18n/project_forecast_line_holidays_public.pot
@@ -4,8 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 15.0\n"
+"Project-Id-Version: Odoo Server 15.0+e\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-09-12 09:37+0000\n"
+"PO-Revision-Date: 2022-09-12 09:37+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -14,11 +16,48 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: project_forecast_line_holidays_public
+#: model_terms:ir.ui.view,arch_db:project_forecast_line_holidays_public.res_config_settings_view_form
+msgid ""
+"<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-"
+"specific.\" aria-label=\"Values set here are company-specific.\" "
+"groups=\"base.group_multi_company\" role=\"img\"/>"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
+#: model:ir.model,name:project_forecast_line_holidays_public.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
+#: model_terms:ir.ui.view,arch_db:project_forecast_line_holidays_public.res_config_settings_view_form
+msgid "Compute forecast on public holidays creation"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
+#: model:ir.model,name:project_forecast_line_holidays_public.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
 #: model:ir.model,name:project_forecast_line_holidays_public.model_forecast_line
 msgid "Forecast"
 msgstr ""
 
 #. module: project_forecast_line_holidays_public
+#: model:ir.model.fields,help:project_forecast_line_holidays_public.field_res_company__immediate_compute_forecast_line
+#: model:ir.model.fields,help:project_forecast_line_holidays_public.field_res_config_settings__immediate_compute_forecast_line
+msgid ""
+"If checked will force forecast lines recomputation on public holidays "
+"creation."
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
 #: model:ir.model,name:project_forecast_line_holidays_public.model_hr_holidays_public_line
 msgid "Public Holidays Lines"
+msgstr ""
+
+#. module: project_forecast_line_holidays_public
+#: model:ir.model.fields,field_description:project_forecast_line_holidays_public.field_res_company__immediate_compute_forecast_line
+#: model:ir.model.fields,field_description:project_forecast_line_holidays_public.field_res_config_settings__immediate_compute_forecast_line
+msgid "Recompute forecast lines immediately"
 msgstr ""

--- a/project_forecast_line_holidays_public/models/__init__.py
+++ b/project_forecast_line_holidays_public/models/__init__.py
@@ -1,2 +1,4 @@
 from . import forecast_line
 from . import hr_holidays_public
+from . import res_company
+from . import res_config_settings

--- a/project_forecast_line_holidays_public/models/hr_holidays_public.py
+++ b/project_forecast_line_holidays_public/models/hr_holidays_public.py
@@ -10,6 +10,7 @@ class HrHolidaysPublicLine(models.Model):
     def create(self, values):
         records = super().create(values)
         # TODO: only recompute if one of the created line is a public holiday
-        # in the horizon
-        self.env["forecast.line"].sudo()._cron_recompute_all()
+        # in the horizon and immediate_compute_forecast_line is checked
+        if self.env.company.immediate_compute_forecast_line:
+            self.env["forecast.line"].sudo()._cron_recompute_all()
         return records

--- a/project_forecast_line_holidays_public/models/res_company.py
+++ b/project_forecast_line_holidays_public/models/res_company.py
@@ -1,0 +1,13 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    immediate_compute_forecast_line = fields.Boolean(
+        string="Recompute forecast lines immediately",
+        default=True,
+        help="If checked will force forecast lines recomputation on public holidays creation.",
+    )

--- a/project_forecast_line_holidays_public/models/res_config_settings.py
+++ b/project_forecast_line_holidays_public/models/res_config_settings.py
@@ -1,0 +1,11 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    immediate_compute_forecast_line = fields.Boolean(
+        related="company_id.immediate_compute_forecast_line", readonly=False
+    )

--- a/project_forecast_line_holidays_public/views/res_config_settings_views.xml
+++ b/project_forecast_line_holidays_public/views/res_config_settings_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field
+            name="inherit_id"
+            ref="project_forecast_line.res_config_settings_view_form"
+        />
+        <field name="arch" type="xml">
+            <div id="forecast_line_settings" position="after">
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="immediate_compute_forecast_line" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="immediate_compute_forecast_line" />
+                        <span
+                            class="fa fa-lg fa-building-o"
+                            title="Values set here are company-specific."
+                            aria-label="Values set here are company-specific."
+                            groups="base.group_multi_company"
+                            role="img"
+                        />
+                        <div class="text-muted">
+                            Compute forecast on public holidays creation
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The issue is that on databases containing lots of employees, projects and tasks, public holidays creation can take huge amount of time or even fail, because forecast lines are recomputed.
We propose to add a setting to choose if we want immediate forecast lines recomputation on public holidays creation. When the setting is not checked, the creation of a public holiday does nothing in the forecast lines.