### PR TITLE
[FIX] project_forecast_line: error in consolidated capacity

### DIFF
--- a/project_forecast_line/models/hr_leave.py
+++ b/project_forecast_line/models/hr_leave.py
@@ -53,6 +53,7 @@ class HrLeave(models.Model):
                 unit_cost=leave.employee_id.timesheet_cost,
                 forecast_role_id=leave.employee_id.main_role_id.id,
                 hr_leave_id=leave.id,
+                employee_id=leave.employee_id.id,
                 res_model=self._name,
                 res_id=leave.id,
             )

--- a/project_forecast_line/tests/test_forecast_line.py
+++ b/project_forecast_line/tests/test_forecast_line.py
@@ -523,6 +523,38 @@ class TestForecastLineProject(BaseForecastLineTest):
                 0.25,
             )
 
+    @freeze_time("2022-01-01 12:00:00")
+    def test_forecast_with_holidays(self):
+        self.test_task_forecast_lines_consolidated_forecast()
+        with Form(self.env["hr.leave"]) as form:
+            form.employee_id = self.employee_consultant
+            form.holiday_status_id = self.env.ref("hr_holidays.holiday_status_unpaid")
+            form.request_date_from = "2022-02-14"
+            form.request_date_to = "2022-02-15"
+            form.request_hour_from = "8"
+            form.request_hour_to = "18"
+        leave_request = form.save()
+        # validating the leave request will recompute the forecast lines for
+        # the employee capactities (actually delete the existing ones and
+        # create new ones -> we check that the project task lines are
+        # automatically related to the new newly created employee role lines.
+        leave_request.action_validate()
+        forecast_lines = self.env["forecast.line"].search(
+            [
+                ("employee_id", "=", self.employee_consultant.id),
+                ("res_model", "=", "hr.employee.forecast.role"),
+                ("date_from", ">=", "2022-02-14"),
+                ("date_to", "<=", "2022-02-15"),
+            ]
+        )
+        self.assertEqual(len(forecast_lines), 2)
+        # both new lines have now a capacity of 0 (employee is on holidays)
+        self.assertEqual(forecast_lines[0].forecast_hours, 0)
+        self.assertEqual(forecast_lines[1].forecast_hours, 0)
+        # first line has a negative consolidated forcast (because of the task)
+        self.assertEqual(forecast_lines[0].consolidated_forecast, -0.75)
+        self.assertEqual(forecast_lines[1].consolidated_forecast, -0)
+
     def test_task_forecast_lines_consolidated_forecast_overallocation(self):
         with freeze_time("2022-01-01"):
             employee_forecast = self.env["forecast.line"].search(


### PR DESCRIPTION
During some operations, forecast lines are deleted and recreated. 

This can lead to some hr.employee.forecast.role lines being deleted which leaves the forecast lines on the same period without a related document to store the consolidated capacity. Normally that line is recreated shortly afterwards but the creation does not recompute the link between the parent-less lines and the new one. This is typically the case when a leave request is confirmed: the forecast line of the leave disapears and the capacity forecast of the employee based on the updated work calendar is regenerated.

This patches forces the recomputation when new lines are created.

It also fixes the missing link to the employee for leave requests forecast lines. 