### PR TITLE
[15.0][FIX] project_timeline: missing action

### DIFF
--- a/project_timeline/views/project_project_view.xml
+++ b/project_timeline/views/project_project_view.xml
@@ -17,6 +17,12 @@
     <record id="project.open_view_project_all" model="ir.actions.act_window">
         <field name="view_mode">kanban,timeline,form</field>
     </record>
+    <record
+        id="project.open_view_project_all_group_stage"
+        model="ir.actions.act_window"
+    >
+        <field name="view_mode">kanban,timeline,form</field>
+    </record>
     <record id="project_project_form" model="ir.ui.view">
         <field name="name">project.project.form</field>
         <field name="model">project.project</field>


### PR DESCRIPTION
Hello,
On my database, the timeline view was not available for projects.
As explained [there](https://github.com/odoo/odoo/blob/1736d5a95825c5fe74c7d0103351efb8565da6ee/addons/project/views/project_views.xml#L743), it is required to modify both actions as sometimes one or the other is used.
