### PR TITLE
[FIX] project_forecast_line: Remove setting and add new consolidated field

### DIFF
--- a/project_forecast_line/models/forecast_line.py
+++ b/project_forecast_line/models/forecast_line.py
@@ -90,13 +90,8 @@ class ForecastLine(models.Model):
         "forecast.line", "employee_resource_forecast_line_id"
     )
 
-    def _get_consumption_states(self):
-        consumption_states = self.env.company.forecast_consumption_states
-        return tuple(consumption_states.split("_"))
-
     @api.depends("employee_id", "date_from", "type", "res_model")
     def _compute_employee_forecast_line_id(self):
-        consumption_states = self._get_consumption_states()
         employees = self.mapped("employee_id")
         main_roles = employees.mapped("main_role_id")
         date_froms = self.mapped("date_from")
@@ -121,10 +116,7 @@ class ForecastLine(models.Model):
                 (line.employee_id.id, line.date_from, line.forecast_role_id.id)
             ] = line.id
         for rec in self:
-            if (
-                rec.type in consumption_states
-                and rec.res_model != "hr.employee.forecast.role"
-            ):
+            if rec.type == "confirmed" and rec.res_model != "hr.employee.forecast.role":
                 resource_forecast_line = capacities.get(
                     (rec.employee_id.id, rec.date_from, rec.forecast_role_id.id), False
                 )

--- a/project_forecast_line/models/hr_leave.py
+++ b/project_forecast_line/models/hr_leave.py
@@ -29,7 +29,13 @@ class HrLeave(models.Model):
             [("res_id", "in", self.ids), ("res_model", "=", self._name)]
         ).unlink()
         leaves = self.filtered_domain([("state", "!=", "refuse")])
-        for leave in leaves:
+        # we need to use sudo here, because forecast line creation
+        # requires access to fields declared on hr.employee
+        # we don't want to restrict them with `groups="hr.group_hr_user"`
+        # as this will require giving access to employee app,
+        # which isn't wanted on some projects
+        # for more details see here: .../addons/hr/models/hr_employee.py#L22
+        for leave in leaves.sudo():
             if not leave.employee_id.main_role_id:
                 _logger.warning(
                     "No forecast role for employee %s (%s)",

--- a/project_forecast_line/models/res_company.py
+++ b/project_forecast_line/models/res_company.py
@@ -14,22 +14,6 @@ class ResCompany(models.Model):
     forecast_line_horizon = fields.Integer(
         help="Number of month for the forecast planning", default=12
     )
-    forecast_consumption_states = fields.Selection(
-        selection=[
-            ("confirmed", "Compute consolidated forecast for lines of type confirmed"),
-            (
-                "forecast_confirmed",
-                "Include lines of type forecast in consolidated forecast computation",
-            ),
-        ],
-        string="Consumption state rules",
-        help="For instance, holidays requests and sales quotation lines"
-        "create lines of type forecast and won't be taken into account"
-        "during consolidated forecast computation, whereas tasks for project"
-        "which are in a running state create lines with type confirmed"
-        "and will be used to compute consolidated forecast.",
-        default="confirmed",
-    )
 
     def write(self, values):
         res = super().write(values)

--- a/project_forecast_line/models/res_config_settings.py
+++ b/project_forecast_line/models/res_config_settings.py
@@ -12,9 +12,7 @@ class ResConfigSettings(models.TransientModel):
     forecast_line_horizon = fields.Integer(
         related="company_id.forecast_line_horizon", readonly=False
     )
-    forecast_consumption_states = fields.Selection(
-        related="company_id.forecast_consumption_states", readonly=False
-    )
+
     group_forecast_line_on_quotation = fields.Boolean(
         "Forecast Line on Quotations",
         implied_group="project_forecast_line.group_forecast_line_on_quotation",

--- a/project_forecast_line/tests/test_forecast_line.py
+++ b/project_forecast_line/tests/test_forecast_line.py
@@ -4,9 +4,10 @@ from datetime import date
 
 from freezegun import freeze_time
 
-from odoo.tests.common import Form, TransactionCase
+from odoo.tests.common import Form, TransactionCase, tagged
 
 
+@tagged("-at_install", "post_install")
 class BaseForecastLineTest(TransactionCase):
     @classmethod
     @freeze_time("2022-01-01")
@@ -489,39 +490,91 @@ class TestForecastLineProject(BaseForecastLineTest):
             }
         )
 
+    def _get_employee_forecast(self):
+        employee_forecast = self.env["forecast.line"].search(
+            [("employee_id", "=", self.employee_consultant.id)]
+        )
+        # we can take first line to check as forecast values are equal
+        forecast_consultant = employee_forecast.filtered(
+            lambda l: l.res_model == "hr.employee.forecast.role"
+            and l.forecast_role_id == self.role_consultant
+        )[0]
+        forecast_pm = employee_forecast.filtered(
+            lambda l: l.res_model == "hr.employee.forecast.role"
+            and l.forecast_role_id == self.role_pm
+        )[0]
+        return forecast_consultant, forecast_pm
+
     def test_task_forecast_lines_consolidated_forecast(self):
-        with freeze_time("2022-01-01"):
-            employee_forecast = self.env["forecast.line"].search(
-                [
-                    ("employee_id", "=", self.employee_consultant.id),
-                    ("date_from", "=", "2022-02-14"),
-                ]
-            )
-            self.assertEqual(len(employee_forecast), 1)
-            project = self.env["project.project"].create({"name": "TestProject"})
-            # set project in stage "in progress" to get confirmed forecast
-            project.stage_id = self.env.ref("project.project_project_stage_1")
-            task = self.env["project.task"].create(
-                {
-                    "name": "Task1",
-                    "project_id": project.id,
-                    "forecast_role_id": self.role_consultant.id,
-                    "forecast_date_planned_start": "2022-02-14",
-                    "forecast_date_planned_end": "2022-02-14",
-                    "planned_hours": 6,
-                }
-            )
-            task.remaining_hours = 6
-            task.user_ids = self.user_consultant
-            forecast = self.env["forecast.line"].search([("task_id", "=", task.id)])
-            self.assertEqual(len(forecast), 1)
-            # using assertEqual on purpose here
-            self.assertEqual(forecast.forecast_hours, -6.0)
-            self.assertAlmostEqual(forecast.consolidated_forecast, 0.75)
-            self.assertEqual(
-                forecast.employee_resource_forecast_line_id.consolidated_forecast,
-                0.25,
-            )
+        self.env["hr.employee.forecast.role"].create(
+            {
+                "employee_id": self.employee_consultant.id,
+                "role_id": self.role_pm.id,
+                "date_start": "2022-01-01",
+                "rate": 25,
+                "sequence": 1,
+            }
+        )
+        consultant_role = self.env["hr.employee.forecast.role"].search(
+            [
+                ("employee_id", "=", self.employee_consultant.id),
+                ("role_id", "=", self.role_consultant.id),
+            ]
+        )
+        consultant_role.rate = 75
+        project_1 = self.env["project.project"].create({"name": "TestProject1"})
+        # set project in stage "to do" to get forecast
+        project_1.stage_id = self.env.ref("project.project_project_stage_0")
+        task_values = {
+            "project_id": project_1.id,
+            "forecast_role_id": self.role_consultant.id,
+            "forecast_date_planned_start": date.today(),
+            "forecast_date_planned_end": date.today(),
+            "planned_hours": 8,
+        }
+        task_values.update({"name": "Task1"})
+        task_1 = self.env["project.task"].create(task_values)
+        task_1.user_ids = self.user_consultant
+        task_values.update({"name": "Task2"})
+        task_2 = self.env["project.task"].create(task_values)
+        task_2.user_ids = self.user_consultant
+        project_2 = self.env["project.project"].create({"name": "TestProject2"})
+        # set project in stage "in progress" to get forecast
+        project_2.stage_id = self.env.ref("project.project_project_stage_1")
+        task_values.update({"project_id": project_2.id, "name": "Task3"})
+        task_3 = self.env["project.task"].create(task_values)
+        task_3.user_ids = self.user_consultant
+        task_values.update({"name": "Task4"})
+        task_4 = self.env["project.task"].create(task_values)
+        task_4.user_ids = self.user_consultant
+        forecast = self.env["forecast.line"].search(
+            [("task_id", "in", (task_1.id, task_2.id, task_3.id, task_4.id))]
+        )
+        self.assertEqual(len(forecast), 4)
+        # as we have multiple tasks to check we will divide by 4
+        self.assertAlmostEqual(sum(f.forecast_hours for f in forecast), -32.0)
+        self.assertAlmostEqual(sum(f.consolidated_forecast for f in forecast), 4.0)
+        self.assertAlmostEqual(
+            sum(f.confirmed_consolidated_forecast for f in forecast), 4.0
+        )
+        consol_employee_forecast = sum(
+            f.employee_resource_forecast_line_id.consolidated_forecast for f in forecast
+        )
+        confir_employee_forecast = sum(
+            f.employee_resource_forecast_line_id.confirmed_consolidated_forecast
+            for f in forecast
+        )
+        self.assertAlmostEqual(consol_employee_forecast, -13.0)
+        self.assertAlmostEqual(confir_employee_forecast, -5.0)
+        forecast_consultant, forecast_pm = self._get_employee_forecast()
+        self.assertEqual(forecast_consultant.forecast_hours, 6.0)
+        self.assertAlmostEqual(forecast_consultant.consolidated_forecast, -3.25)
+        self.assertAlmostEqual(
+            forecast_consultant.confirmed_consolidated_forecast, -1.25
+        )
+        self.assertEqual(forecast_pm.forecast_hours, 2.0)
+        self.assertAlmostEqual(forecast_pm.consolidated_forecast, 0.25)
+        self.assertAlmostEqual(forecast_pm.confirmed_consolidated_forecast, 0.25)
 
     def test_task_forecast_lines_consolidated_forecast_overallocation(self):
         with freeze_time("2022-01-01"):
@@ -552,8 +605,13 @@ class TestForecastLineProject(BaseForecastLineTest):
             # using assertEqual on purpose here
             self.assertEqual(forecast.forecast_hours, -10.0)
             self.assertEqual(forecast.consolidated_forecast, 1.25)
+            self.assertEqual(forecast.confirmed_consolidated_forecast, 1.25)
             self.assertEqual(
                 forecast.employee_resource_forecast_line_id.consolidated_forecast,
+                -0.25,
+            )
+            self.assertEqual(
+                forecast.employee_resource_forecast_line_id.confirmed_consolidated_forecast,
                 -0.25,
             )
 
@@ -605,6 +663,10 @@ class TestForecastLineProject(BaseForecastLineTest):
             )
             self.assertAlmostEqual(
                 forecast1.employee_resource_forecast_line_id.consolidated_forecast,
+                -0.75,
+            )
+            self.assertAlmostEqual(
+                forecast1.employee_resource_forecast_line_id.confirmed_consolidated_forecast,
                 -0.75,
             )
 
@@ -661,22 +723,16 @@ class TestForecastLineProject(BaseForecastLineTest):
         # using assertEqual on purpose here
         self.assertEqual(task_forecast.forecast_hours, -8.0)
         self.assertEqual(task_forecast.consolidated_forecast, 1.0)
-        employee_forecast = self.env["forecast.line"].search(
-            [("employee_id", "=", self.employee_consultant.id)]
-        )
-        # we can take first line to check as forecast values are equal
-        forecast_consultant = employee_forecast.filtered(
-            lambda l: l.res_model == "hr.employee.forecast.role"
-            and l.forecast_role_id == self.role_consultant
-        )[0]
+        self.assertEqual(task_forecast.confirmed_consolidated_forecast, 1.0)
+        forecast_consultant, forecast_pm = self._get_employee_forecast()
         self.assertEqual(forecast_consultant.forecast_hours, 6.0)
         self.assertAlmostEqual(forecast_consultant.consolidated_forecast, -0.25)
-        forecast_pm = employee_forecast.filtered(
-            lambda l: l.res_model == "hr.employee.forecast.role"
-            and l.forecast_role_id == self.role_pm
-        )[0]
+        self.assertAlmostEqual(
+            forecast_consultant.confirmed_consolidated_forecast, -0.25
+        )
         self.assertEqual(forecast_pm.forecast_hours, 2.0)
         self.assertAlmostEqual(forecast_pm.consolidated_forecast, 0.25)
+        self.assertAlmostEqual(forecast_pm.confirmed_consolidated_forecast, 0.25)
 
     def test_task_forecast_lines_employee_main_role(self):
         """
@@ -732,19 +788,13 @@ class TestForecastLineProject(BaseForecastLineTest):
         # using assertEqual on purpose here
         self.assertEqual(task_forecast.forecast_hours, -8.0)
         self.assertEqual(task_forecast.consolidated_forecast, 1.0)
-        employee_forecast = self.env["forecast.line"].search(
-            [("employee_id", "=", self.employee_consultant.id)]
-        )
-        # we can take first line to check as forecast values are equal
-        forecast_consultant = employee_forecast.filtered(
-            lambda l: l.res_model == "hr.employee.forecast.role"
-            and l.forecast_role_id == self.role_consultant
-        )[0]
+        self.assertEqual(task_forecast.confirmed_consolidated_forecast, 1.0)
+        forecast_consultant, forecast_pm = self._get_employee_forecast()
         self.assertEqual(forecast_consultant.forecast_hours, 6.0)
         self.assertAlmostEqual(forecast_consultant.consolidated_forecast, -0.25)
-        forecast_pm = employee_forecast.filtered(
-            lambda l: l.res_model == "hr.employee.forecast.role"
-            and l.forecast_role_id == self.role_pm
-        )[0]
+        self.assertAlmostEqual(
+            forecast_consultant.confirmed_consolidated_forecast, -0.25
+        )
         self.assertEqual(forecast_pm.forecast_hours, 2.0)
         self.assertAlmostEqual(forecast_pm.consolidated_forecast, 0.25)
+        self.assertAlmostEqual(forecast_pm.confirmed_consolidated_forecast, 0.25)

--- a/project_forecast_line/views/forecast_line_views.xml
+++ b/project_forecast_line/views/forecast_line_views.xml
@@ -64,7 +64,8 @@
                 <field name="date_to" />
                 <field name="forecast_hours" />
                 <field name="cost" />
-                <field name="consolidated_forecast" />
+                <field name="confirmed_consolidated_forecast" optional="show" />
+                <field name="consolidated_forecast" optional="show" />
                 <field name="forecast_role_id" />
                 <field name="currency_id" invisible="1" />
             </tree>
@@ -76,6 +77,7 @@
             <graph type="bar" stacked="0">
                 <field name="date_from" type="row" />
                 <field name="forecast_role_id" type="col" />
+                <field name="confirmed_consolidated_forecast" type="measure" />
                 <field name="consolidated_forecast" type="measure" />
                 <field name="cost" type="measure" />
                 <field name="forecast_hours" type="measure" />
@@ -91,6 +93,7 @@
                 <field name="date_from" type="row" />
                 <field name="employee_id" type="col" />
                 <field name="project_id" type="col" />
+                <field name="confirmed_consolidated_forecast" type="measure" />
                 <field name="consolidated_forecast" type="measure" />
             </graph>
         </field>
@@ -101,6 +104,7 @@
             <pivot>
                 <field name="date_from" type="col" />
                 <field name="forecast_role_id" type="row" />
+                <field name="confirmed_consolidated_forecast" type="measure" />
                 <field name="consolidated_forecast" type="measure" />
                 <field name="cost" type="measure" />
                 <field name="forecast_hours" type="measure" />

--- a/project_forecast_line/views/res_config_settings_views.xml
+++ b/project_forecast_line/views/res_config_settings_views.xml
@@ -50,17 +50,6 @@
                                             class="o_field_integer o_field_number o_field_widget o_input oe_inline col-lg-2"
                                         />
                                     </div>
-                                    <div class="mt8">
-                                        <label for="forecast_consumption_states" />
-                                        <div class="text-muted">
-                                            Select the states for which the consumption is confirmed or not
-                                        </div>
-                                        <field
-                                            name="forecast_consumption_states"
-                                            required="1"
-                                            class="o_light_label"
-                                        />
-                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
The idea is to have two consolidated forecast fields, instead of setting.