### PR TITLE
[14.0][IMP] project_stock: Add analytic date

### DIFF
--- a/project_stock/i18n/es.po
+++ b/project_stock/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-31 15:24+0000\n"
-"PO-Revision-Date: 2022-05-31 17:25+0200\n"
+"POT-Creation-Date: 2022-09-15 14:02+0000\n"
+"PO-Revision-Date: 2022-09-15 16:02+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: project_stock
 #: model:ir.model.fields,field_description:project_stock.field_project_task__allow_moves_action_assign
@@ -41,6 +41,12 @@ msgstr "Línea Analítica"
 #: model:ir.model.fields,field_description:project_stock.field_project_task__stock_analytic_line_ids
 msgid "Analytic Lines"
 msgstr "Líneas analíticas"
+
+#. module: project_stock
+#: model:ir.model.fields,field_description:project_stock.field_project_project__stock_analytic_date
+#: model:ir.model.fields,field_description:project_stock.field_project_task__stock_analytic_date
+msgid "Analytic date"
+msgstr "Fecha para analítica"
 
 #. module: project_stock
 #: model:ir.model.fields.selection,name:project_stock.selection__project_task__stock_state__assigned
@@ -107,7 +113,7 @@ msgstr "Realizar movimientos hechos"
 #. module: project_stock
 #: model:ir.model.fields,field_description:project_stock.field_project_task__group_id
 msgid "Group"
-msgstr ""
+msgstr "Grupo"
 
 #. module: project_stock
 #: model:ir.model.fields,help:project_stock.field_project_task__done_stock_moves

--- a/project_stock/i18n/project_stock.pot
+++ b/project_stock/i18n/project_stock.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-09-15 14:02+0000\n"
+"PO-Revision-Date: 2022-09-15 14:02+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -36,6 +38,12 @@ msgstr ""
 #. module: project_stock
 #: model:ir.model.fields,field_description:project_stock.field_project_task__stock_analytic_line_ids
 msgid "Analytic Lines"
+msgstr ""
+
+#. module: project_stock
+#: model:ir.model.fields,field_description:project_stock.field_project_project__stock_analytic_date
+#: model:ir.model.fields,field_description:project_stock.field_project_task__stock_analytic_date
+msgid "Analytic date"
 msgstr ""
 
 #. module: project_stock

--- a/project_stock/models/project_project.py
+++ b/project_stock/models/project_project.py
@@ -30,6 +30,7 @@ class ProjectProject(models.Model):
         check_company=True,
         help="Default location to which materials are consumed.",
     )
+    stock_analytic_date = fields.Date(string="Analytic date")
 
     @api.onchange("picking_type_id")
     def _onchange_picking_type_id(self):

--- a/project_stock/models/project_task.py
+++ b/project_stock/models/project_task.py
@@ -61,6 +61,7 @@ class ProjectTask(models.Model):
         index=True,
         check_company=True,
     )
+    stock_analytic_date = fields.Date(string="Analytic date")
     unreserve_visible = fields.Boolean(
         string="Allowed to Unreserve Inventory",
         compute="_compute_unreserve_visible",

--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -33,6 +33,11 @@ class StockMove(models.Model):
         if not analytic_account:
             return False
         res = {
+            "date": (
+                task.stock_analytic_date
+                or task.project_id.stock_analytic_date
+                or fields.date.today()
+            ),
             "name": task.name + ": " + product.name,
             "unit_amount": self.quantity_done,
             "account_id": analytic_account.id,

--- a/project_stock/tests/common.py
+++ b/project_stock/tests/common.py
@@ -64,6 +64,7 @@ class TestProjectStockBase(common.SavepointCase):
                 "picking_type_id": cls.picking_type.id,
                 "location_id": cls.picking_type.default_location_src_id.id,
                 "location_dest_id": cls.picking_type.default_location_dest_id.id,
+                "stock_analytic_date": "1990-01-01",
             }
         )
         cls.stage_in_progress = cls.env["project.task.type"].create(

--- a/project_stock/tests/test_project_stock.py
+++ b/project_stock/tests/test_project_stock.py
@@ -1,5 +1,6 @@
 # Copyright 2022 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields
 from odoo.tests import Form
 from odoo.tests.common import new_test_user
 
@@ -71,18 +72,35 @@ class TestProjectStock(TestProjectStockBase):
         self.task.write({"stage_id": self.stage_done.id})
         self.task.action_done()
         self._test_task_analytic_lines_from_task(-40)
+        self.assertEqual(
+            fields.first(self.task.stock_analytic_line_ids).date,
+            fields.Date.from_string("1990-01-01"),
+        )
 
     def test_project_task_analytic_lines_with_tag_1(self):
-        self.task.write({"stock_analytic_tag_ids": self.analytic_tag_1.ids})
+        self.task.write(
+            {
+                "stock_analytic_date": "1991-01-01",
+                "stock_analytic_tag_ids": self.analytic_tag_1.ids,
+            }
+        )
         self.task.write({"stage_id": self.stage_done.id})
         self.task.action_done()
         self._test_task_analytic_lines_from_task(-40)
+        self.assertEqual(
+            fields.first(self.task.stock_analytic_line_ids).date,
+            fields.Date.from_string("1991-01-01"),
+        )
 
     def test_project_task_analytic_lines_with_tag_2(self):
+        self.task.project_id.stock_analytic_date = False
         self.task.write({"stock_analytic_tag_ids": self.analytic_tag_2.ids})
         self.task.write({"stage_id": self.stage_done.id})
         self.task.action_done()
         self._test_task_analytic_lines_from_task(-20)
+        self.assertEqual(
+            fields.first(self.task.stock_analytic_line_ids).date, fields.date.today()
+        )
 
     def test_project_task_process_done(self):
         self.assertEqual(self.move_product_a.state, "draft")

--- a/project_stock/views/project_project_view.xml
+++ b/project_stock/views/project_project_view.xml
@@ -16,6 +16,7 @@
                         name="location_dest_id"
                         groups="stock.group_stock_multi_locations"
                     />
+                    <field name="stock_analytic_date" />
                 </group>
             </xpath>
         </field>

--- a/project_stock/views/project_task_view.xml
+++ b/project_stock/views/project_task_view.xml
@@ -37,6 +37,7 @@
                     attrs="{'invisible': [('use_stock_moves', '=', False)]}"
                     widget="many2many_tags"
                 />
+                <field name="stock_analytic_date" />
             </field>
             <field name="stage_id" position="before">
                 <button


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/project/pull/982

The possibility of set a specific date in project or task has been added so that if it is set it will be used in analytic items linked to materials.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT38988