### PR TITLE
[IMP][14.0]project_parent_task_filter

### DIFF
--- a/project_parent_task_filter/__manifest__.py
+++ b/project_parent_task_filter/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Project Parent Task Filter",
-    "summary": "Add a filter to show the parent tasks",
+    "summary": "Add filters to show the parent or non parent tasks",
     "version": "14.0.1.1.0",
     "category": "Project",
     "website": "https://github.com/OCA/project",

--- a/project_parent_task_filter/readme/CONTRIBUTORS.rst
+++ b/project_parent_task_filter/readme/CONTRIBUTORS.rst
@@ -3,3 +3,7 @@
   * Eduardo Magdalena <emagdalena@c2i.es>
 
 * Stephan Keller <MiStK@gmx.de>
+
+* `Ooops <http://ooops404.com/>`_:
+
+  * Ashish Hirpara <ashish.hirapara1995@gmail.com>

--- a/project_parent_task_filter/readme/DESCRIPTION.rst
+++ b/project_parent_task_filter/readme/DESCRIPTION.rst
@@ -1,4 +1,4 @@
-This module adds a filter to show only the parent tasks in a project and
+This module adds two filters to show only the parent or non-parent tasks in a project and
 a group to sort tasks by its parent tasks.
 It also adds the subtask number in the kanban view and activates the use
 of subtasks in the project settings.

--- a/project_parent_task_filter/views/project_task.xml
+++ b/project_parent_task_filter/views/project_task.xml
@@ -13,6 +13,11 @@
                     name="parent_only"
                     domain="[('parent_id','=',False)]"
                 />
+                <filter
+                    string="Non-parent tasks"
+                    name="parent_only"
+                    domain="[('child_ids','=',False)]"
+                />
             </xpath>
             <xpath expr="//filter[@name='group_create_date']" position="after">
                 <filter


### PR DESCRIPTION
added a "Non-parent tasks" filter in task kanban which only displays tasks where "sub-tasks" is not set.