### PR TITLE
[FIX] project_task_code: in place argument modification

### DIFF
--- a/project_task_code/models/project_task.py
+++ b/project_task_code/models/project_task.py
@@ -15,10 +15,16 @@ class ProjectTask(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        new_list = []
         for vals in vals_list:
             if vals.get("code", "/") == "/":
-                vals["code"] = self.env["ir.sequence"].next_by_code("project.task")
-        return super().create(vals_list)
+                new_vals = dict(
+                    vals, code=self.env["ir.sequence"].next_by_code("project.task")
+                )
+            else:
+                new_vals = vals
+            new_list.append(new_vals)
+        return super().create(new_list)
 
     def copy(self, default=None):
         self.ensure_one()


### PR DESCRIPTION
The overload of project.task::create  in the project_task_code would mutate the dictionaries passed in the vals_list argument. This is a bad practice which can have unintended side effects in caller code.

We fix this by creating a new dictionary containing the additional field value and passing this dictionary in the call to super().create()