### PR TITLE
[15.0][FIX] Odoo recursive warning

### DIFF
--- a/project_role/models/project_role.py
+++ b/project_role/models/project_role.py
@@ -35,6 +35,7 @@ class ProjectRole(models.Model):
     complete_name = fields.Char(
         compute="_compute_complete_name",
         store=True,
+        recursive=True,
     )
     name = fields.Char(
         translate=True,

--- a/project_type/models/project_type.py
+++ b/project_type/models/project_type.py
@@ -14,7 +14,11 @@ class ProjectType(models.Model):
         comodel_name="project.type", inverse_name="parent_id", string="Subtypes"
     )
     name = fields.Char(required=True, translate=True)
-    complete_name = fields.Char(compute="_compute_complete_name", store=True)
+    complete_name = fields.Char(
+        compute="_compute_complete_name",
+        store=True,
+        recursive=True,
+    )
     description = fields.Text(translate=True)
     project_ok = fields.Boolean(string="Can be applied for projects", default=True)
     task_ok = fields.Boolean(string="Can be applied for tasks")


### PR DESCRIPTION
There are two warnings on startup/installation in the logs:

WARNING py.warnings: /opt/odoo/odoo/fields.py:722: UserWarning: Field project.role.complete_name should be declared with recursive=True
WARNING py.warnings: /opt/odoo/odoo/fields.py:722: UserWarning: Field project.type.complete_name should be declared with recursive=True