### PR TITLE
[15.0][IMP] project_forecast_line: Some improvements

### DIFF
--- a/project_forecast_line/models/forecast_line.py
+++ b/project_forecast_line/models/forecast_line.py
@@ -158,8 +158,16 @@ class ForecastLine(models.Model):
             data[line_id][d["type"]] += d["forecast_hours"]
         return data
 
+    @api.model
+    def _get_consolidation_uom(self):
+        """
+        Returns the unit of measure used for the consolidated forecast.
+        The default is days.
+        """
+        return self.env.ref("uom.product_uom_day")
+
     def _convert_hours_to_days(self, hours):
-        to_convert_uom = self.env.ref("uom.product_uom_day")
+        to_convert_uom = self._get_consolidation_uom()
         project_time_mode_id = self.company_id.project_time_mode_id
         return project_time_mode_id._compute_quantity(
             hours, to_convert_uom, round=False

--- a/project_forecast_line/models/project_project.py
+++ b/project_forecast_line/models/project_project.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 
+from ..utils import get_written_computed_fields
+
 
 class ProjectProject(models.Model):
     _inherit = "project.project"
@@ -9,10 +11,15 @@ class ProjectProject(models.Model):
     def _update_forecast_lines_trigger_fields(self):
         return ["stage_id"]
 
+    # TODO: Stored computed fields updates don't go through write,
+    # but they do go through _write. Check if possible to override
+    # that method instead, to avoid maintaing get_written_computed_fields
     def write(self, values):
         res = super().write(values)
-        written_fields = list(values.keys())
+        written_computed_fields = get_written_computed_fields(
+            self, tuple(sorted(values))
+        )
         trigger_fields = self._update_forecast_lines_trigger_fields()
-        if any(field in written_fields for field in trigger_fields):
+        if any(field in written_computed_fields for field in trigger_fields):
             self.task_ids._update_forecast_lines()
         return res

--- a/project_forecast_line/models/sale_order_line.py
+++ b/project_forecast_line/models/sale_order_line.py
@@ -4,6 +4,8 @@ import logging
 
 from odoo import api, fields, models
 
+from ..utils import get_written_computed_fields
+
 _logger = logging.getLogger(__name__)
 
 
@@ -85,11 +87,16 @@ class SaleOrderLine(models.Model):
             "name",
         ]
 
+    # TODO: Stored computed fields updates don't go through write,
+    # but they do go through _write. Check if possible to override
+    # that method instead, to avoid maintaing get_written_computed_fields
     def write(self, values):
         res = super().write(values)
-        written_fields = list(values.keys())
+        written_computed_fields = get_written_computed_fields(
+            self, tuple(sorted(values))
+        )
         trigger_fields = self._update_forecast_lines_trigger_fields()
-        if any(field in written_fields for field in trigger_fields):
+        if any(field in written_computed_fields for field in trigger_fields):
             self._update_forecast_lines()
         return res
 

--- a/project_forecast_line/utils.py
+++ b/project_forecast_line/utils.py
@@ -1,0 +1,40 @@
+# Copyright 2022 Camptocamp SA
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import tools
+from odoo.models import trigger_tree_merge
+
+
+def get_field_dependencies_tree(model_obj, fnames):
+    """
+    Returns a tree of all dependant fields,
+    that will be triggered to recompute if fnames are modified.
+    See ``modified`` of models.py
+    """
+    if len(fnames) == 1:
+        tree = model_obj.pool.field_triggers.get(model_obj._fields[next(iter(fnames))])
+    else:
+        # merge dependency trees to evaluate all triggers at once
+        tree = {}
+        for fname in fnames:
+            node = model_obj.pool.field_triggers.get(model_obj._fields[fname])
+            if node:
+                trigger_tree_merge(tree, node)
+    return tree
+
+
+@tools.ormcache("values")
+def get_written_computed_fields(model_obj, values):
+    """
+    Returns field names tuple of written and computed fields
+    """
+    task_computed = tuple()
+    tree = get_field_dependencies_tree(model_obj, values)
+    if tree:
+        tocompute = (
+            model_obj.sudo().with_context(active_test=False)._modified_triggers(tree)
+        )
+        for field, _records, _create in tocompute:
+            if field.model_name == model_obj._name:
+                task_computed += (field.name,)
+    return values + task_computed

--- a/project_forecast_line/views/forecast_line_views.xml
+++ b/project_forecast_line/views/forecast_line_views.xml
@@ -4,10 +4,10 @@
         <field name="model">forecast.line</field>
         <field name="arch" type="xml">
             <search>
-                <field name="name" />
+                <field name="employee_id" />
+                <field name="name" string="Forecast" />
                 <field name="forecast_role_id" />
                 <field name="project_id" />
-                <field name="employee_id" />
                 <field name="company_id" groups="base.group_multi_company" />
                 <filter
                     string="Forecast"


### PR DESCRIPTION
1. Add computed fields to written fields to trigger forecast lines update
To reproduce the case:
  - Create forecast on project task for example.
  - Change initially planned hours.
  - Forecast lines are not recomputed.
What is expected:
when initially planned hours are changed remaining hours are being recomputed. And it should trigger forecast line update.
2. Add hook for several UoM hours/days conversion
3. Reorder forecast search filters.