### PR TITLE
[14.0][FIX] project_timesheet_time_control: Avoid texts on buttons

### DIFF
--- a/project_timesheet_time_control/views/account_analytic_line_view.xml
+++ b/project_timesheet_time_control/views/account_analytic_line_view.xml
@@ -15,23 +15,21 @@
                 <field name="show_time_control" invisible="1" />
                 <button
                     name="button_resume_work"
-                    string="Resume work"
                     tabindex="-1"
                     type="object"
                     icon="fa-play-circle text-success"
                     attrs="{'invisible': [('show_time_control', '!=', 'resume')]}"
                     class="oe_stat_button"
-                    title="Start work"
+                    title="Resume work"
                 />
                 <button
                     name="button_end_work"
-                    string="Stop work"
                     tabindex="-1"
                     type="object"
                     icon="fa-stop-circle text-warning"
                     attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
                     class="oe_stat_button"
-                    title="End work"
+                    title="Stop work"
                 />
             </field>
         </field>
@@ -48,22 +46,20 @@
                 <field name="show_time_control" invisible="1" />
                 <button
                     name="button_resume_work"
-                    string="Resume work"
                     type="object"
                     icon="fa-play-circle text-success"
                     attrs="{'invisible': [('show_time_control', '!=', 'resume')]}"
                     class="oe_stat_button"
                     context="{'show_created_timer': True}"
-                    title="Start work"
+                    title="Resume work"
                 />
                 <button
                     name="button_end_work"
-                    string="Stop work"
                     type="object"
                     icon="fa-stop-circle text-warning"
                     attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
                     class="oe_stat_button"
-                    title="End work"
+                    title="Stop work"
                 />
             </div>
             <field name="date" position="attributes">

--- a/project_timesheet_time_control/views/project_task_view.xml
+++ b/project_timesheet_time_control/views/project_task_view.xml
@@ -48,7 +48,7 @@
                 <field name="show_time_control" invisible="1" />
                 <button
                     name="button_resume_work"
-                    string="Resume work"
+                    title="Resume work"
                     tabindex="-1"
                     type="object"
                     icon="fa-play-circle text-success"
@@ -57,7 +57,7 @@
                 />
                 <button
                     name="button_end_work"
-                    string="Stop work"
+                    title="Stop work"
                     tabindex="-1"
                     type="object"
                     icon="fa-stop-circle text-warning"
@@ -123,24 +123,22 @@
                     <field name="show_time_control" invisible="1" />
                     <button
                         name="button_resume_work"
-                        string="Resume work"
                         tabindex="-1"
                         type="object"
                         icon="fa-play-circle text-success"
                         attrs="{'invisible': [('show_time_control', '!=', 'resume')]}"
                         class="oe_stat_button"
                         context="{'show_created_timer': True}"
-                        title="Start work"
+                        title="Resume work"
                     />
                     <button
                         name="button_end_work"
-                        string="Stop work"
                         tabindex="-1"
                         type="object"
                         icon="fa-stop-circle text-warning"
                         attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
                         class="oe_stat_button"
-                        title="End work"
+                        title="Stop work"
                     />
                 </div>
             </xpath>
@@ -161,7 +159,6 @@
                     name="button_start_work"
                     attrs="{'invisible': [('show_time_control', '!=', 'start')]}"
                     class="o_kanban_inline_block fa fa-lg fa-play-circle text-success"
-                    string="Start work"
                     tabindex="-1"
                     type="object"
                     title="Start work"
@@ -170,10 +167,9 @@
                     name="button_end_work"
                     attrs="{'invisible': [('show_time_control', '!=', 'stop')]}"
                     class="o_kanban_inline_block fa fa-lg fa-stop-circle text-warning"
-                    string="Stop work"
                     tabindex="-1"
                     type="object"
-                    title="End work"
+                    title="Stop work"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Since v14, `string` attribute of <button> elements are directly shown in the views as text instead of being a tooltip, and thus, it takes a lot of space in screen.

And it was not the intended visualization when the module was conceived, just a side effect.

Thus, we restore what we expect, moving `string` to `title` for having the tooltips again.

**Before**

![imagen](https://user-images.githubusercontent.com/7165771/197859632-571e6c94-8937-4725-ac02-634f5c4b49a8.png)

**After**

![Selección_004](https://user-images.githubusercontent.com/7165771/197859418-a62fa92e-5d2f-49c3-b57a-8cb26f2eb1bf.png)


@Tecnativa TT40169