### PR TITLE
[15.0][UPD] project_forecast_line: update forecast lines even if employee is not active

### DIFF
--- a/project_forecast_line/models/project_task.py
+++ b/project_forecast_line/models/project_task.py
@@ -71,6 +71,9 @@ class ProjectTask(models.Model):
                     task.forecast_role_id = employee.main_role_id
                     break
 
+    def _get_task_employees(self):
+        return self.with_context(active_test=False).mapped("user_ids.employee_id")
+
     def _update_forecast_lines(self):
         today = fields.Date.context_today(self)
         forecast_vals = []
@@ -116,7 +119,7 @@ class ProjectTask(models.Model):
                 continue
             date_start = max(today, task.forecast_date_planned_start)
             date_end = max(today, task.forecast_date_planned_end)
-            employee_ids = task.mapped("user_ids.employee_id").ids
+            employee_ids = task._get_task_employees().ids
             if not employee_ids:
                 employee_ids = [False]
             _logger.debug(


### PR DESCRIPTION
We want to update forecast lines even if the employee is not active.
Hook can be overridden in custom modules to update only active employees with simple filtered.
```
def _get_task_employees(self):
    employees = super()._get_task_employees()
    return employees.filtered("active")
```