### PR TITLE
[14.0][IMP] project_stock: Avoid defining the project in the analytic items to avoid incoherence.

### DIFF
--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -59,6 +59,9 @@ class StockMove(models.Model):
             vals["ref"] = task.name
         if "product_id" in analytic_line_fields:
             vals["product_id"] = product.id
+        # Prevent incoherence when hr_timesheet addon is installed.
+        if "project_id" in analytic_line_fields:
+            vals["project_id"] = False
         # Extra field added in hr_timesheet addon
         if "employee_id" in analytic_line_fields:
             vals["employee_id"] = (

--- a/project_stock/tests/test_project_stock.py
+++ b/project_stock/tests/test_project_stock.py
@@ -66,6 +66,9 @@ class TestProjectStock(TestProjectStockBase):
             self.analytic_account,
             self.task.stock_analytic_line_ids.mapped("account_id"),
         )
+        # Prevent incoherence when hr_timesheet addon is installed.
+        if "project_id" in self.task.stock_analytic_line_ids._fields:
+            self.assertFalse(self.task.stock_analytic_line_ids.project_id)
 
     def test_project_task_without_analytic_account(self):
         # Prevent error when hr_timesheet addon is installed.


### PR DESCRIPTION
Related to: https://github.com/OCA/project/issues/1043

Avoid defining the project in the analytic items to avoid incoherence.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa