### PR TITLE
[15.0][IMP] project_stock: Avoid defining the project in the analytic items to avoid incoherence.

### DIFF
--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -60,6 +60,9 @@ class StockMove(models.Model):
             vals["ref"] = task.name
         if "product_id" in analytic_line_fields:
             vals["product_id"] = product.id
+        # Prevent incoherence when hr_timesheet addon is installed.
+        if "project_id" in analytic_line_fields:
+            vals["project_id"] = False
         # tags + distributions
         if task.stock_analytic_tag_ids:
             vals["tag_ids"] = [(6, 0, task.stock_analytic_tag_ids.ids)]

--- a/project_stock/tests/test_project_stock.py
+++ b/project_stock/tests/test_project_stock.py
@@ -68,6 +68,9 @@ class TestProjectStock(TestProjectStockBase):
             self.analytic_account,
             stock_analytic_lines.mapped("account_id"),
         )
+        # Prevent incoherence when hr_timesheet addon is installed.
+        if "project_id" in self.task.stock_analytic_line_ids._fields:
+            self.assertFalse(self.task.stock_analytic_line_ids.project_id)
 
     def test_project_task_without_analytic_account(self):
         self.task = self.env["project.task"].browse(self.task.id)


### PR DESCRIPTION
Related to: https://github.com/OCA/project/issues/1043
FWP from 14.0: https://github.com/OCA/project/pull/1047

Avoid defining the project in the analytic items to avoid incoherence.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa