### PR TITLE
[FIX] project_task_code: Make sequence available for all companies

### DIFF
--- a/project_task_code/data/task_sequence.xml
+++ b/project_task_code/data/task_sequence.xml
@@ -8,5 +8,6 @@
         <field name="code">project.task</field>
         <field eval="4" name="padding" />
         <field name="prefix">T</field>
+        <field name="company_id" eval="False" />
     </record>
 </odoo>


### PR DESCRIPTION
Currently, the sequence that generates task codes is only available for the
main company [1], which could cause issues at the moment of the installation
process with another modules in multi-companies cases, for example
project_timesheet_holiday [2] because in the other companies, this line [3]
will return False or "/" and will trigger the UNIQUE constraint. With
this change, the sequence can be used by any company [4] using the False
value in the field company_id.

References:
[1] https://github.com/odoo/odoo/blob/7b6c25e/odoo/addons/base/models/ir_sequence.py#L148
[2] https://github.com/odoo/odoo/blob/7b6c25e/addons/project_timesheet_holidays/models/res_company.py#L14
[3] https://github.com/OCA/project/blob/9d08f2d/project_task_code/models/project_task.py#L29
[4] https://github.com/odoo/odoo/blob/7b6c25e/odoo/addons/base/models/ir_sequence.py#L282