### PR TITLE
[14.0][FIX] project_stock_product_set: Set group_id allways in new stock moves from wizard

### DIFF
--- a/project_stock/models/project_task.py
+++ b/project_stock/models/project_task.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022-2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -125,6 +125,14 @@ class ProjectTask(models.Model):
             already_reserved = item.mapped("move_ids.move_line_ids")
             any_quantity_done = any([m.quantity_done > 0 for m in item.move_ids])
             item.unreserve_visible = not any_quantity_done and already_reserved
+
+    def _set_procurement_group_id(self):
+        """We use this method to auto-set group_id always and use it in other addons."""
+        self.ensure_one()
+        if not self.group_id:
+            self.group_id = self.env["procurement.group"].create(
+                self._prepare_procurement_group_vals()
+            )
 
     @api.onchange("picking_type_id")
     def _onchange_picking_type_id(self):

--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022-2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from odoo import api, fields, models
 
@@ -93,10 +93,7 @@ class StockMove(models.Model):
             task = self.env["project.task"].browse(
                 self.env.context.get("default_raw_material_task_id")
             )
-            if not task.group_id:
-                task.group_id = self.env["procurement.group"].create(
-                    task._prepare_procurement_group_vals()
-                )
+            task._set_procurement_group_id()  # Define group_id only if necessary
             defaults.update(
                 {
                     "group_id": task.group_id.id,

--- a/project_stock_product_set/models/product_set_line.py
+++ b/project_stock_product_set/models/product_set_line.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022-2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from odoo import models
 
@@ -7,7 +7,6 @@ class ProductSetLine(models.Model):
     _inherit = "product.set.line"
 
     def prepare_stock_move_values(self, task, quantity):
-        self.ensure_one()
         return {
             "name": self.product_id.display_name,
             "product_id": self.product_id.id,
@@ -18,6 +17,7 @@ class ProductSetLine(models.Model):
             "location_dest_id": (
                 task.location_dest_id.id or task.project_id.location_dest_id.id
             ),
+            "group_id": task.group_id.id,
             "state": "draft",
             "raw_material_task_id": task.id,
             "picking_type_id": task.picking_type_id.id

--- a/project_stock_product_set/tests/test_project_stock_product_set.py
+++ b/project_stock_product_set/tests/test_project_stock_product_set.py
@@ -22,7 +22,7 @@ class TestProjectStockProductSet(TestProjectStockBase):
         )
 
     @users("project-task-user")
-    def test_wizard_product_set_add(self):
+    def test_wizard_product_set_add_1(self):
         self.assertFalse(self.task.move_ids)
         wizard_form = Form(
             self.env["product.set.add.from.task"].with_context(
@@ -32,7 +32,47 @@ class TestProjectStockProductSet(TestProjectStockBase):
         wizard_form.product_set_id = self.product_set
         wizard = wizard_form.save()
         wizard.add_set()
+        self.assertTrue(self.task.group_id)
         self.assertEqual(len(self.task.move_ids), 2)
         self.assertIn(self.product_a, self.task.move_ids.mapped("product_id"))
         self.assertIn(self.product_b, self.task.move_ids.mapped("product_id"))
         self.assertEqual(sum(self.task.move_ids.mapped("product_uom_qty")), 3)
+        self.task.action_confirm()
+        self.assertEqual(len(self.task.move_ids), 2)
+        move_a = self.task.move_ids.filtered(lambda x: x.product_id == self.product_a)
+        self.assertEqual(move_a.group_id, self.task.group_id)
+        move_b = self.task.move_ids.filtered(lambda x: x.product_id == self.product_b)
+        self.assertEqual(move_b.group_id, self.task.group_id)
+
+    @users("project-task-user")
+    def test_wizard_product_set_add_2(self):
+        # Create manual product before
+        task_form = Form(self.task)
+        with task_form.move_ids.new() as move_form:
+            move_form.product_id = self.product_c
+            move_form.product_uom_qty = 1
+        task_form.save()
+        self.assertEqual(len(self.task.move_ids), 1)
+        self.assertTrue(self.task.group_id)
+        # Wizard to add set
+        wizard_form = Form(
+            self.env["product.set.add.from.task"].with_context(
+                default_task_id=self.task.id
+            )
+        )
+        wizard_form.product_set_id = self.product_set
+        wizard = wizard_form.save()
+        wizard.add_set()
+        self.assertTrue(self.task.group_id)
+        self.assertEqual(len(self.task.move_ids), 3)
+        self.assertIn(self.product_a, self.task.move_ids.mapped("product_id"))
+        self.assertIn(self.product_b, self.task.move_ids.mapped("product_id"))
+        self.assertEqual(sum(self.task.move_ids.mapped("product_uom_qty")), 4)
+        self.task.action_confirm()
+        self.assertEqual(len(self.task.move_ids), 3)
+        move_a = self.task.move_ids.filtered(lambda x: x.product_id == self.product_a)
+        self.assertEqual(move_a.group_id, self.task.group_id)
+        move_b = self.task.move_ids.filtered(lambda x: x.product_id == self.product_b)
+        self.assertEqual(move_b.group_id, self.task.group_id)
+        move_c = self.task.move_ids.filtered(lambda x: x.product_id == self.product_c)
+        self.assertEqual(move_c.group_id, self.task.group_id)

--- a/project_stock_product_set/wizard/product_set_add.py
+++ b/project_stock_product_set/wizard/product_set_add.py
@@ -34,6 +34,7 @@ class ProductSetAddFromTask(models.TransientModel):
         if not self.task_id:
             return super().add_set()
         self._check_partner()
+        self.task_id._set_procurement_group_id()  # We make sure it is defined
         move_lines = self._prepare_stock_move_lines()
         if move_lines:
             self.task_id.write({"move_ids": move_lines})


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/project/pull/1083

Set group_id allways in new stock moves from wizard

This problem exists since https://github.com/OCA/project/commit/1b8a63e75ab168460e28679b585d3f0f586f0cbb

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa TT42000