### PR TITLE
[15.0][FIX][project_timesheet_time_control] Error: AttributeError: type object 'expression' has no attribute AND

### DIFF
--- a/project_timesheet_time_control/wizards/hr_timesheet_switch.py
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch.py
@@ -3,7 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-from odoo.osv.expression import expression
+from odoo.osv import expression
 
 
 class HrTimesheetSwitch(models.TransientModel):


### PR DESCRIPTION
It seems that "expression" is not correctly imported from odoo.osv. 


This causes the error:

"AttributeError: type object 'expression' has no attribute 'AND'" when this code block is executed:

`            return expression.AND(
                [
                    domain,
                    [
                        "|",
                        ("privacy_visibility", "!=", "followers"),
                        ("message_partner_ids", "in", [self.env.user.partner_id.id]),
                    ],
                ]
            )`

