### PR TITLE
[14.0][FIX] project_timesheet_time_control: compatibility with hr_timesheet_sheet

### DIFF
--- a/project_timesheet_time_control/wizards/hr_timesheet_switch.py
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch.py
@@ -123,6 +123,9 @@ class HrTimesheetSwitch(models.TransientModel):
                 # error because time_stop - time_start must equal duration.
                 "time_start",
                 "time_stop",
+                # Field from hr_timesheet_sheet, not a dependency
+                # can cause interference and undesired behaviours
+                "sheet_id",
             }
             inherited.read(_fields)
             values = inherited._convert_to_write(inherited._cache)


### PR DESCRIPTION
Quick and dirty fix for a field coming from hr_timesheet_sheet (https://github.com/OCA/timesheet) that can at times appear on the timesheet_switch wizard and that causes problems (plus, its value isn't read from the wizard itself on save, causing confusion for users); much like the other exceptions that have been added.

It seems to me like ultimately it'd be best to drop the inheritance from account.analytic.line and redefine the wizard with only the necessary fields, but that's beyond the scope of this PR.

To test the bug with the old version:

0. Install project_timesheet_time_control and hr_timesheet_sheet
1. create a timesheet sheet
2. create an analytic line for a task (open it and close it)
3. confirm the timesheet sheet
4. use the "play" button to add more work on the task: the timesheet_sheet will be pre-filled with the now-closed sheet and it'll be impossible to confirm it. (which is expected behaviour) However, changing the sheet_id field to another sheet, or making it empty, will be ignored and the previous error will remain. (this is the bug being fixed)