### PR TITLE
[FIX] project_forecast_line: disappearing forecast

### DIFF
--- a/project_forecast_line/models/hr_employee.py
+++ b/project_forecast_line/models/hr_employee.py
@@ -111,7 +111,7 @@ class HrEmployeeForecastRole(models.Model):
                 date_end = rec.date_end
                 ForecastLine.search(
                     [
-                        ("res_id", "in", self.ids),
+                        ("res_id", "=", rec.id),
                         ("res_model", "=", self._name),
                         ("date_to", ">=", date_end),
                     ]


### PR DESCRIPTION
Fix an issue in project_forecast_line where lines would be removed by
the cron.

When an employee has a forecast role with an end date set, depending on
the order of the processing of records in the cron, a bug could remove
forecast lines of other employees when attempting to remove the forecast
lines related to thatrole which had been generated after the end date in
previous runs (before the end date was set).

Fix this by using the correct domain.
