### PR TITLE
[FIX] project_forecast_line issues

### DIFF
--- a/project_forecast_line/models/hr_employee.py
+++ b/project_forecast_line/models/hr_employee.py
@@ -107,6 +107,7 @@ class HrEmployeeForecastRole(models.Model):
         ).unlink()
         horizon_end = ForecastLine._company_horizon_end()
         for rec in self:
+            ForecastLine = ForecastLine.with_company(rec.company_id)
             if rec.date_end:
                 date_end = rec.date_end
                 ForecastLine.search(

--- a/project_forecast_line/models/hr_leave.py
+++ b/project_forecast_line/models/hr_leave.py
@@ -49,6 +49,7 @@ class HrLeave(models.Model):
                 continue
             else:
                 forecast_type = "forecast"
+            ForecastLine = ForecastLine.with_company(leave.employee_company_id)
             forecast_vals += ForecastLine._prepare_forecast_lines(
                 name=_("Leave"),
                 date_from=leave.date_from.date(),

--- a/project_forecast_line/models/project_task.py
+++ b/project_forecast_line/models/project_task.py
@@ -99,7 +99,10 @@ class ProjectTask(models.Model):
                 # normal flow
                 task._update_forecast_lines()
                 continue
-            ratio = task.remaining_hours / total_forecast
+            # caution: total_forecast is negative -> make sure we have a
+            # positive ratio, so that the multiplication does not change the
+            # sign of the forecast
+            ratio = abs(task.remaining_hours / total_forecast)
             for line in forecast_lines:
                 line.forecast_hours *= ratio
 

--- a/project_forecast_line/models/project_task.py
+++ b/project_forecast_line/models/project_task.py
@@ -94,7 +94,7 @@ class ProjectTask(models.Model):
                 [("res_model", "=", self._name), ("res_id", "=", task.id)]
             )
             total_forecast = sum(forecast_lines.mapped("forecast_hours"))
-            if not forecast_lines or total_forecast:
+            if not forecast_lines or not total_forecast:
                 # no existing forecast lines, try to generate some using the
                 # normal flow
                 task._update_forecast_lines()

--- a/project_forecast_line/models/project_task.py
+++ b/project_forecast_line/models/project_task.py
@@ -144,6 +144,7 @@ class ProjectTask(models.Model):
         ForecastLine = self.env["forecast.line"].sudo()
         task_with_lines_to_clean = []
         for task in self:
+            task = task.with_company(task.company_id)
             if not task._should_have_forecast():
                 task_with_lines_to_clean.append(task.id)
                 continue
@@ -184,6 +185,7 @@ class ProjectTask(models.Model):
                         ("employee_id", "=", employee_id),
                     ]
                 )
+                ForecastLine = ForecastLine.with_company(employee_id.company_id)
                 forecast_vals += employee_lines._update_forecast_lines(
                     name=task.name,
                     date_from=date_start,

--- a/project_forecast_line/models/project_task.py
+++ b/project_forecast_line/models/project_task.py
@@ -108,6 +108,8 @@ class ProjectTask(models.Model):
         if not self.forecast_role_id:
             _logger.info("skip task %s: no forecast role", self)
             return False
+        elif not self.project_id:
+            _logger.info("skip task %s: no project", self)
         elif self.project_id.stage_id:
             forecast_type = self.project_id.stage_id.forecast_line_type
             if not forecast_type:
@@ -155,6 +157,11 @@ class ProjectTask(models.Model):
                     forecast_type = "confirmed"
                 else:
                     forecast_type = "forecast"
+            else:
+                _logger.warn(
+                    "strange case -> undefined forecast type for %s: skip", task
+                )
+                continue
 
             date_start = max(today, task.forecast_date_planned_start)
             date_end = max(today, task.forecast_date_planned_end)

--- a/project_forecast_line/models/sale_order_line.py
+++ b/project_forecast_line/models/sale_order_line.py
@@ -28,6 +28,7 @@ class SaleOrderLine(models.Model):
             [("res_id", "in", self.ids), ("res_model", "=", self._name)]
         ).unlink()
         for line in self:
+            ForecastLine = ForecastLine.with_company(line.company_id)
             if not line.product_id.forecast_role_id:
                 continue
             elif line.state in ("cancel", "sale"):


### PR DESCRIPTION
- [FIX] forecast_line: issue in multicompany leading to wrong forecast
- [FIX] wrong condition preventing project.task quick update path to be used
- [FIX] wrong result when project.task quick update path is used (inversion of the sign of the task forecast)
- [FIX] crash when a task is not related to a project
