### PR TITLE
[15.0][IMP] project_timesheet_time_control: Add base.group_multi_company group to company_id field from wizard

### DIFF
--- a/project_timesheet_time_control/wizards/hr_timesheet_switch_view.xml
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch_view.xml
@@ -22,7 +22,7 @@
                         <field name="date_time_end" />
                         <field name="project_id" required="1" />
                         <field name="task_id" />
-                        <field name="company_id" />
+                        <field name="company_id" groups="base.group_multi_company" />
                     </group>
                     <group
                         name="messages"


### PR DESCRIPTION
Add `base.group_multi_company` group to `company_id` field from wizard (similar to 14.0: https://github.com/odoo/odoo/blob/14.0/addons/hr_timesheet/views/hr_timesheet_views.xml#L93)

Please @pedrobaeza and @CarlosRoca13 can you review it?

@Tecnativa