### PR TITLE
[ADD] [16.0] Project Portal Custom Field Access

### DIFF
--- a/project_portal_custom_field_access/README.rst
+++ b/project_portal_custom_field_access/README.rst
@@ -1,0 +1,1 @@
+# TO BE GENERATED

--- a/project_portal_custom_field_access/__init__.py
+++ b/project_portal_custom_field_access/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/project_portal_custom_field_access/__manifest__.py
+++ b/project_portal_custom_field_access/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Project Portal Custom Field Access",
+    "summary": "Grant the Portal User access to custom Project Task fields",
+    "version": "16.0.1.0.0",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
+    "maintainers": ["ivantodorovich"],
+    "website": "https://github.com/OCA/project",
+    "license": "AGPL-3",
+    "category": "Project Management",
+    "depends": ["project"],
+    "data": ["views/ir_model_fields.xml"],
+}

--- a/project_portal_custom_field_access/models/__init__.py
+++ b/project_portal_custom_field_access/models/__init__.py
@@ -1,0 +1,2 @@
+from . import ir_model_fields
+from . import project_task

--- a/project_portal_custom_field_access/models/ir_model_fields.py
+++ b/project_portal_custom_field_access/models/ir_model_fields.py
@@ -1,0 +1,26 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+
+
+class IrModelFields(models.Model):
+    _inherit = "ir.model.fields"
+
+    project_portal_access = fields.Boolean(
+        string="Shared with Project Portal Users",
+        help="Allow Project Portal Users to access this field.\n"
+        "This is only applicable to custom fields, and it doesn't automatically add "
+        "the field to any portal view.",
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        if any(vals.get("project_portal_access") for vals in vals_list):
+            self.env["project.task"]._get_portal_custom_field_access.clear_cache(self)
+        return super().create(vals_list)
+
+    def write(self, vals):
+        if "project_portal_access" in vals:
+            self.env["project.task"]._get_portal_custom_field_access.clear_cache(self)
+        return super().write(vals)

--- a/project_portal_custom_field_access/models/project_task.py
+++ b/project_portal_custom_field_access/models/project_task.py
@@ -1,0 +1,30 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+from odoo.tools import ormcache
+
+
+class ProjectTask(models.Model):
+    _inherit = "project.task"
+
+    @api.model
+    @ormcache()
+    def _get_portal_custom_field_access(self):
+        res = (
+            self.env["ir.model.fields"]
+            .sudo()
+            .search_read(
+                [
+                    ("model", "=", self._name),
+                    ("state", "=", "manual"),
+                    ("project_portal_access", "=", True),
+                ],
+                ["name"],
+            )
+        )
+        return {r["name"] for r in res}
+
+    @property
+    def SELF_WRITABLE_FIELDS(self):
+        return super().SELF_WRITABLE_FIELDS | self._get_portal_custom_field_access()

--- a/project_portal_custom_field_access/readme/CONTRIBUTORS.rst
+++ b/project_portal_custom_field_access/readme/CONTRIBUTORS.rst
@@ -1,0 +1,3 @@
+* `Camptocamp <https://www.camptocamp.com>`_
+
+  * Iván Todorovich <ivan.todorovich@camptocamp.com>

--- a/project_portal_custom_field_access/readme/DESCRIPTION.rst
+++ b/project_portal_custom_field_access/readme/DESCRIPTION.rst
@@ -1,0 +1,12 @@
+Odoo has a feature called "Project Sharing" that allows portal users to view a project's
+kanban, which has functionalities similar to the backend system.
+
+There's a preset list of fields that portal users can access, which is harcoded in the
+module's source code.
+
+That's nice but inconvinient if a user introduces new fields to the form and wants to
+share these with the portal users. They can't currently do this without using a Python
+override.
+
+To resolve this, the module lets users whitelist these custom fields directly through
+the ``ir.model.field`` model.

--- a/project_portal_custom_field_access/readme/USAGE.rst
+++ b/project_portal_custom_field_access/readme/USAGE.rst
@@ -1,0 +1,2 @@
+Go to the custom ``ir.model.field`` record and set the field ``project_portal_access``
+to ``True``. Note that the option is displayed only for custom ``project.task`` fields.

--- a/project_portal_custom_field_access/tests/__init__.py
+++ b/project_portal_custom_field_access/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_project_portal_custom_field_access

--- a/project_portal_custom_field_access/tests/test_project_portal_custom_field_access.py
+++ b/project_portal_custom_field_access/tests/test_project_portal_custom_field_access.py
@@ -1,0 +1,47 @@
+# Copyright 2023 Camptocamp SA (https://www.camptocamp.com).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.exceptions import AccessError
+from odoo.tests.common import users
+
+from odoo.addons.project.tests.test_access_rights import TestAccessRights
+
+
+class TestAccessRightsCustomFields(TestAccessRights):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, tracking_disable=True))
+        # Set up a few custom fields
+        cls.model_project_task = cls.env.ref("project.model_project_task")
+        cls.field_custom_test = cls.env["ir.model.fields"].create(
+            {
+                "name": "x_test",
+                "model_id": cls.model_project_task.id,
+                "ttype": "char",
+                "project_portal_access": True,
+            }
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.project_pigs.privacy_visibility = "portal"
+        self.project_pigs.message_subscribe(partner_ids=self.portal.partner_id.ids)
+
+    @users("Portal user")
+    def test_task_custom_field_access_allowed(self):
+        task = self.task.with_user(self.env.user)
+        task.read(["x_test"])
+
+    @users("Portal user")
+    def test_task_custom_field_access_not_allowed(self):
+        self.field_custom_test.project_portal_access = False
+        task = self.task.with_user(self.env.user)
+        with self.assertRaises(AccessError):
+            task.read(["x_test"])
+
+    @users("Internal user")
+    def test_task_custom_field_access_internal_user_allowed(self):
+        self.field_custom_test.project_portal_access = False
+        task = self.task.with_user(self.env.user)
+        task.read(["x_test"])

--- a/project_portal_custom_field_access/views/ir_model_fields.xml
+++ b/project_portal_custom_field_access/views/ir_model_fields.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_model_fields_form" model="ir.ui.view">
+        <field name="model">ir.model.fields</field>
+        <field name="inherit_id" ref="base.view_model_fields_form" />
+        <field name="arch" type="xml">
+            <field name="translate" position="after">
+                <field name="model" invisible="1" />
+                <field
+                    name="project_portal_access"
+                    attrs="{'invisible': ['|', ('model', '!=', 'project.task'), ('state', '!=', 'manual')]}"
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/setup/project_portal_custom_field_access/odoo/addons/project_portal_custom_field_access
+++ b/setup/project_portal_custom_field_access/odoo/addons/project_portal_custom_field_access
@@ -1,0 +1,1 @@
+../../../../project_portal_custom_field_access

--- a/setup/project_portal_custom_field_access/setup.py
+++ b/setup/project_portal_custom_field_access/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Odoo has a feature called "Project Sharing" that allows portal users to view a project's kanban, which has functionalities similar to the backend system.

There's a preset list of fields that portal users can access, which is harcoded in the module's source code.

That's nice but inconvinient if a user introduces new fields to the form and wants to share these with the portal users. They can't currently do this without using a Python override.

To resolve this, the module lets users whitelist these custom fields directly through the ``ir.model.field`` model.