### PR TITLE
[FIX] [15.0] project_forecast_line: Fixed bug by adding hr.group_hr_user group 

### DIFF
--- a/project_forecast_line/models/hr_employee.py
+++ b/project_forecast_line/models/hr_employee.py
@@ -15,9 +15,21 @@ class HrJob(models.Model):
 class HrEmployee(models.Model):
     _inherit = "hr.employee"
 
-    role_ids = fields.One2many("hr.employee.forecast.role", "employee_id")
+    # NB: these fields need to be marked as groups="hr.groups_hr_user",
+    # because otherwise if a user with less privileges tries to read
+    # hr.employee.public, they'll get an AccessError on these fields.
+    # More info at: https://github.com/odoo/odoo/blob/d21887008b1ac7
+    # 69bd91d24e972323ffe936391a/addons/hr/models/hr_employee.py#L22
+    role_ids = fields.One2many(
+        "hr.employee.forecast.role",
+        "employee_id",
+        groups="hr.group_hr_user",
+    )
     main_role_id = fields.Many2one(
-        "forecast.role", compute="_compute_main_role_id", ondelete="restrict"
+        "forecast.role",
+        compute="_compute_main_role_id",
+        ondelete="restrict",
+        groups="hr.group_hr_user",
     )
 
     def _compute_main_role_id(self):


### PR DESCRIPTION
Fixed bug by adding `hr.group_hr_user ` group to field not available in hr.employee.public.

Basically same as [this](https://github.com/OCA/hr/pull/1261/files) and Odoo explains as [this](https://github.com/odoo/odoo/blob/c55badb8d70bdccfeb82bffb330d3f0b1b162ed1/addons/hr/models/hr_employee.py#L23).

If this is not done, it can lead to `ValueError: Invalid field 'role_ids' on model 'hr.employee.public'` for users with no `hr.employee` rights.