### PR TITLE
[IMP] project_task_dependency: Search by recursive dependency

### DIFF
--- a/project_task_dependency/tests/test_project_task_dependency.py
+++ b/project_task_dependency/tests/test_project_task_dependency.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016-2018 Onestein (<http://www.onestein.eu>)
+# Copyright 2023 Simone Rubino - TAKOBI
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.exceptions import ValidationError
@@ -39,3 +40,16 @@ class TestProjectTaskDependency(TransactionCase):
             self.task1.write({
                 'dependency_task_ids': [(6, 0, [self.task3.id])]
             })
+
+    def test_search_recursive_dependency(self):
+        result = self.env['project.task'].search([
+            ('recursive_dependency_task_ids', 'in', self.task1.ids),
+        ])
+        self.assertIn(self.task2, result)
+        self.assertIn(self.task3, result)
+
+        result = self.env['project.task'].search([
+            ('recursive_dependency_task_ids', 'not in', self.task1.ids),
+        ])
+        self.assertNotIn(self.task2, result)
+        self.assertNotIn(self.task3, result)


### PR DESCRIPTION
This is just the beginning for allowing to search on the many new _dependency/depending_ fields that are not stored.

Without this, when searching by `recursive_dependency_task_ids` I see the log:
> ERROR <db_name> odoo.osv.expression: Non-stored field project.task.recursive_dependency_task_ids cannot be searched.

This might be extended to the other fields and I hope someone else is maybe able to cover the other operators too.

I know this is not a complete solution but is probably better than an error in the log.

This should be also rather easy to forward-port in active versions, I'm sorry to propose this for `10.0` but I need it for this version.
If/When approved, I'll happily consider to forward-port :)