### PR TITLE
[14.0][FIX]project_recalculate: Fix errors and add tests

### DIFF
--- a/project_recalculate/models/project_task.py
+++ b/project_recalculate/models/project_task.py
@@ -124,7 +124,7 @@ class ProjectTask(models.Model):
             - company
         """
         self.ensure_one()
-        resource = False
+        resource = None
         if self.user_id:
             # Get first resource of assigned user
             resource = self.env["resource.resource"].search(

--- a/project_recalculate/models/resource_calendar.py
+++ b/project_recalculate/models/resource_calendar.py
@@ -3,6 +3,8 @@
 from datetime import datetime, timedelta
 from functools import partial
 
+from pytz import timezone
+
 from odoo import models
 
 from odoo.addons.resource.models.resource import make_aware
@@ -14,9 +16,13 @@ class ResourceCalendar(models.Model):
     def get_working_days_of_date(self, start_dt=None, end_dt=None, resource=None):
         self.ensure_one()
         if start_dt is None:
+            tz = timezone(self.tz)
             start_dt = datetime.now().replace(hour=0, minute=0, second=0)
+            start_dt = tz.localize(start_dt)
         if end_dt is None:
+            tz = timezone(self.tz)
             end_dt = datetime.now().replace(hour=23, minute=59, second=59)
+            end_dt = tz.localize(end_dt)
         days = 0
         current = start_dt
         while current <= end_dt:

--- a/project_recalculate/tests/__init__.py
+++ b/project_recalculate/tests/__init__.py
@@ -2,3 +2,4 @@
 
 from . import test_project_project
 from . import test_project_task
+from . import test_resource_calendar

--- a/project_recalculate/tests/test_project_task.py
+++ b/project_recalculate/tests/test_project_task.py
@@ -154,6 +154,33 @@ class TestProjectTaskBegin(base.BaseCase):
                 },
             )
 
+    def test_project_recalculate_no_user_id_and_project_id_resource_calendar_id(self):
+        # No user_id and project_id.resource_calendar_id
+        resource_calendar_id = self.env.ref("resource.resource_calendar_std")
+        for name, start, end in self.project_init_dates:
+            project = self.project_create(
+                self.num_tasks,
+                {
+                    "calculation_type": self.calculation_type,
+                    "name": name,
+                    "date_start": start,
+                    "date": end,
+                    "resource_calendar_id": resource_calendar_id.id,
+                },
+            )
+            for task in project.tasks:
+                task.user_id = False
+            project.project_recalculate()
+
+            if project.calculation_type == "date_begin":
+                self.assertEqual(
+                    project.date, max(project.tasks.mapped("date_end")).date()
+                )
+            else:
+                self.assertEqual(
+                    project.date_start, min(project.tasks.mapped("date_start")).date()
+                )
+
 
 class TestProjectTaskEnd(TestProjectTaskBegin):
     calculation_type = "date_end"

--- a/project_recalculate/tests/test_resource_calendar.py
+++ b/project_recalculate/tests/test_resource_calendar.py
@@ -1,0 +1,90 @@
+from datetime import date, datetime
+
+from pytz import utc
+
+from . import base
+
+
+class TestResourceCalendar(base.BaseCase):
+    # This is necesary to test like this to increment
+    # test coverage, because it's not posible in code
+    # to get this states
+
+    def test_get_working_days_of_date_no_date_start(self):
+        company = self.env.user.company_id
+        calendar = self.env["resource.calendar"].search(
+            [("company_id", "=", company.id)], limit=1
+        )
+        resource = self.env["resource.resource"].search(
+            [("user_id", "=", self.env.user.id)], limit=1
+        )
+        # start_dt < end_dt
+        days = calendar.get_working_days_of_date(
+            start_dt=utc.localize(datetime(2023, 7, 10)),
+            end_dt=utc.localize(datetime(2023, 7, 11)),
+            resource=resource,
+        )
+        self.assertEqual(days, 1)
+
+        # start_dt > end_dt
+        days = calendar.get_working_days_of_date(
+            start_dt=utc.localize(datetime(2023, 7, 10)),
+            end_dt=utc.localize(datetime(2023, 7, 1)),
+            resource=resource,
+        )
+        self.assertEqual(days, 0)
+
+        # No end_dt
+        days = calendar.get_working_days_of_date(
+            start_dt=utc.localize(datetime(2023, 7, 10)),
+            resource=resource,
+        )
+        self.assertTrue(days > 0)
+
+        # No start_dt and end_dt
+        days = calendar.get_working_days_of_date(
+            resource=resource,
+        )
+        self.assertEqual(days, 0)
+
+        # No start_dt
+        days = calendar.get_working_days_of_date(
+            end_dt=utc.localize(datetime(2023, 7, 10)),
+            resource=resource,
+        )
+        self.assertEqual(days, 0)
+
+        # No resource
+        days = calendar.get_working_days_of_date(
+            start_dt=utc.localize(datetime(2023, 7, 10)),
+            end_dt=utc.localize(datetime(2023, 7, 11)),
+        )
+        self.assertEqual(days, 1)
+
+    def test_plan_days_to_resource(self):
+        company = self.env.user.company_id
+        calendar = self.env["resource.calendar"].search(
+            [("company_id", "=", company.id)], limit=1
+        )
+        project = self.project_create(
+            self.num_tasks,
+            {
+                "calculation_type": self.calculation_type,
+                "name": "Test project",
+                "date_start": date(2015, 8, 1),
+                "date": date(2015, 8, 31),
+                "resource_calendar_id": False,
+            },
+        )
+
+        task = project.tasks[0]
+
+        # No compute_leaves
+        planned_dt = calendar.plan_days_to_resource(0, task.date_start)
+        self.assertEqual(task.date_start, planned_dt)
+
+        # From days = 0
+        planned_dt = calendar.plan_days_to_resource(
+            0, task.date_start, compute_leaves=True
+        )
+        self.assertEqual(task.date_start, planned_dt)


### PR DESCRIPTION
Fixes 2 errors,
1.In _resource_calendar_select(), resource must be set to None insted to False, to prevent bool has no .id
2.In get_working_days_of_date you must assign a tz to start_dt and end_date if it's not defiened, in order to be able to compare aware
 dates