### PR TITLE
[15.0][FIX] project_stock: Filter valid stock moves (avoiding those done and cancelled) in action_done() to avoid side effects.

### DIFF
--- a/project_stock/models/project_task.py
+++ b/project_stock/models/project_task.py
@@ -224,7 +224,10 @@ class ProjectTask(models.Model):
         return True
 
     def action_done(self):
-        for move in self.mapped("move_ids"):
+        # Filter valid stock moves (avoiding those done and cancelled).
+        for move in self.mapped("move_ids").filtered(
+            lambda x: x.state not in ("done", "cancel")
+        ):
             move.quantity_done = move.reserved_availability
         self.mapped("move_ids")._action_done()
         # Use sudo to avoid error for users with no access to analytic

--- a/project_stock/tests/common.py
+++ b/project_stock/tests/common.py
@@ -7,6 +7,16 @@ class TestProjectStockBase(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                mail_create_nolog=True,
+                mail_create_nosubscribe=True,
+                mail_notrack=True,
+                no_reset_password=True,
+                tracking_disable=True,
+            )
+        )
         cls.product_a = cls.env["product.product"].create(
             {"name": "Test product A", "detailed_type": "product", "standard_price": 10}
         )
@@ -47,36 +57,21 @@ class TestProjectStockBase(common.TransactionCase):
         cls.stage_in_progress = cls.env.ref("project.project_stage_1")
         cls.stage_done = cls.env.ref("project.project_stage_2")
         group_stock_user = "stock.group_stock_user"
-        ctx = {
-            "mail_create_nolog": True,
-            "mail_create_nosubscribe": True,
-            "mail_notrack": True,
-            "no_reset_password": True,
-        }
         new_test_user(
             cls.env,
             login="basic-user",
             groups="project.group_project_user,%s" % group_stock_user,
-            context=ctx,
         )
         new_test_user(
             cls.env,
             login="manager-user",
             groups="project.group_project_manager,%s,analytic.group_analytic_accounting"
             % group_stock_user,
-            context=ctx,
         )
-        ctx = {
-            "mail_create_nolog": True,
-            "mail_create_nosubscribe": True,
-            "mail_notrack": True,
-            "no_reset_password": True,
-        }
         new_test_user(
             cls.env,
             login="project-task-user",
             groups="project.group_project_user,stock.group_stock_user",
-            context=ctx,
         )
 
     def _prepare_context_task(self):

--- a/project_stock/tests/test_project_stock.py
+++ b/project_stock/tests/test_project_stock.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022-2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import fields
 from odoo.tests import Form
@@ -234,6 +234,31 @@ class TestProjectStock(TestProjectStockBase):
         self.assertEqual(self.move_product_a.reserved_availability, 0)
         self.assertEqual(self.move_product_b.reserved_availability, 0)
         self.assertFalse(self.task.unreserve_visible)
+
+    def test_project_task_process_01(self):
+        """Product A move cancel + Product B move OK."""
+        self.task = self.env["project.task"].browse(self.task.id)
+        self.move_product_b.unlink()
+        self.assertEqual(self.move_product_a.state, "draft")
+        # Confirm + Edit to qty=0
+        self.task.action_confirm()
+        self.assertEqual(self.move_product_a.state, "assigned")
+        self.move_product_a.product_uom_qty = 0
+        self.task.action_done()
+        self.assertEqual(self.move_product_a.state, "cancel")
+        # Add extra line
+        task_form = Form(self.task)
+        with task_form.move_ids.new() as move_form:
+            move_form.product_id = self.product_b
+            move_form.product_uom_qty = 1
+        task_form.save()
+        self.move_product_b = self.task.move_ids.filtered(
+            lambda x: x.product_id == self.product_b
+        )
+        self.task.action_confirm()
+        self.assertEqual(self.move_product_b.state, "assigned")
+        self.task.action_done()
+        self.assertEqual(self.move_product_b.state, "done")
 
     @users("basic-user")
     def test_project_task_process_unreserve_basic_user(self):


### PR DESCRIPTION
Filter valid stock moves (avoiding those done and cancelled) in action_done() to avoid side effects.

Use case:
- Product A with 1 qty
- Confirm materials
- Edit Product A line to 0 qty
- Transfer Materials
- New line: Product B with 1 qty
- Confirm materials
- Transfer Materials (previously, the error https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_move.py#L585 would be displayed.)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT44572