### PR TITLE
[16.0][FIX] project_stock: Filter valid stock moves (avoiding those done and cancelled) in action_done() to avoid side effects.

### DIFF
--- a/project_stock/models/project_task.py
+++ b/project_stock/models/project_task.py
@@ -215,7 +215,10 @@ class ProjectTask(models.Model):
         return True
 
     def action_done(self):
-        for move in self.mapped("move_ids"):
+        # Filter valid stock moves (avoiding those done and cancelled).
+        for move in self.mapped("move_ids").filtered(
+            lambda x: x.state not in ("done", "cancel")
+        ):
             move.quantity_done = move.reserved_availability
         self.mapped("move_ids")._action_done()
         # Use sudo to avoid error for users with no access to analytic

--- a/project_stock/tests/common.py
+++ b/project_stock/tests/common.py
@@ -9,6 +9,16 @@ class TestProjectStockBase(common.TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                mail_create_nolog=True,
+                mail_create_nosubscribe=True,
+                mail_notrack=True,
+                no_reset_password=True,
+                tracking_disable=True,
+            )
+        )
         cls.product_a = cls.env["product.product"].create(
             {"name": "Test product A", "detailed_type": "product", "standard_price": 10}
         )
@@ -44,24 +54,21 @@ class TestProjectStockBase(common.TransactionCase):
         cls.stage_in_progress = cls.env.ref("project.project_stage_1")
         cls.stage_done = cls.env.ref("project.project_stage_2")
         group_stock_user = "stock.group_stock_user"
-        ctx = {
-            "mail_create_nolog": True,
-            "mail_create_nosubscribe": True,
-            "mail_notrack": True,
-            "no_reset_password": True,
-        }
         new_test_user(
             cls.env,
             login="basic-user",
             groups="project.group_project_user,%s" % group_stock_user,
-            context=ctx,
         )
         new_test_user(
             cls.env,
             login="manager-user",
             groups="project.group_project_manager,%s,analytic.group_analytic_accounting"
             % group_stock_user,
-            context=ctx,
+        )
+        new_test_user(
+            cls.env,
+            login="project-task-user",
+            groups="project.group_project_user,stock.group_stock_user",
         )
 
     def _prepare_context_task(self):


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/project/pull/1163

Filter valid stock moves (avoiding those done and cancelled) in action_done() to avoid side effects.

Use case:
- Product A with 1 qty
- Confirm materials
- Edit Product A line to 0 qty
- Transfer Materials
- New line: Product B with 1 qty
- Confirm materials
- Transfer Materials (previously, the error https://github.com/odoo/odoo/blob/15.0/addons/stock/models/stock_move.py#L585 would be displayed.)

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT44572