### PR TITLE
[15.0][FIX] project_stock: Avoid creating multiple analytical items in the "Transfer Materials" process.

### DIFF
--- a/project_stock/models/project_task.py
+++ b/project_stock/models/project_task.py
@@ -229,10 +229,10 @@ class ProjectTask(models.Model):
             lambda x: x.state not in ("done", "cancel")
         ):
             move.quantity_done = move.reserved_availability
-        self.mapped("move_ids")._action_done()
+        moves_todo = self.mapped("move_ids")._action_done()
         # Use sudo to avoid error for users with no access to analytic
         analytic_line_model = self.env["account.analytic.line"].sudo()
-        for move in self.move_ids.filtered(lambda x: x.state == "done"):
+        for move in moves_todo:
             vals = move._prepare_analytic_line_from_task()
             if vals:
                 analytic_line_model.create(vals)

--- a/project_stock/tests/test_project_stock.py
+++ b/project_stock/tests/test_project_stock.py
@@ -260,6 +260,17 @@ class TestProjectStock(TestProjectStockBase):
         self.task.action_done()
         self.assertEqual(self.move_product_b.state, "done")
 
+    def test_project_task_process_02(self):
+        self.task.action_confirm()
+        self.assertEqual(self.move_product_a.state, "assigned")
+        self.assertEqual(self.move_product_b.state, "assigned")
+        self.task.action_done()
+        self.assertEqual(self.move_product_a.state, "done")
+        self.assertEqual(self.move_product_b.state, "done")
+        self.assertEqual(len(self.task.stock_analytic_line_ids), 2)
+        self.task.action_done()
+        self.assertEqual(len(self.task.stock_analytic_line_ids), 2)
+
     @users("basic-user")
     def test_project_task_process_unreserve_basic_user(self):
         self.test_project_task_process_unreserve()


### PR DESCRIPTION
Avoid creating multiple analytical items in the "_Transfer Materials_" process.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT44572