### PR TITLE
[16.0][IMP] project_role: Add unaccent=False to parent_path field

### DIFF
--- a/project_role/models/project_role.py
+++ b/project_role/models/project_role.py
@@ -17,9 +17,7 @@ class ProjectRole(models.Model):
     active = fields.Boolean(
         default=True,
     )
-    parent_path = fields.Char(
-        index=True,
-    )
+    parent_path = fields.Char(index=True, unaccent=False)
     parent_id = fields.Many2one(
         string="Parent Role",
         comodel_name="project.role",


### PR DESCRIPTION
Add `unaccent=False` to `parent_path` field to avoid odoo warning `odoo.models: parent_path field on model 'project.role' should have unaccent disabled. Add 'unaccent=False' to the field definition.`