### PR TITLE
[FIX] project_task_link: Fix 'xpath by class' warning

### DIFF
--- a/project_task_link/views/project_project_views.xml
+++ b/project_task_link/views/project_project_views.xml
@@ -5,7 +5,7 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project" />
         <field name="arch" type="xml">
-            <xpath expr="//sheet//div[@class='oe_button_box']" position="inside">
+            <xpath expr="//sheet//div[hasclass('oe_button_box')]" position="inside">
                 <button
                     name="%(project.act_project_project_2_project_task_all)d"
                     type="action"


### PR DESCRIPTION
The CI shows a warning ```Error-prone use of @class in view project.project.form.inherit (): use the hasclass(*classes) function to filter elements by their classes```