### PR TITLE
[15.0][FIX] project_wbs: fix code, indent consistency and list view

### DIFF
--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -191,13 +191,11 @@ class Project(models.Model):
     )
     wbs_indent = fields.Char(
         related="analytic_account_id.wbs_indent",
-        readonly=False,
     )
     complete_wbs_code = fields.Char(
         related="analytic_account_id.complete_wbs_code",
         string="WBS Code",
         store=True,
-        readonly=False,
     )
     code = fields.Char(
         related="analytic_account_id.code",
@@ -205,7 +203,6 @@ class Project(models.Model):
     )
     complete_wbs_name = fields.Char(
         related="analytic_account_id.complete_wbs_name",
-        readonly=False,
     )
     project_analytic_id = fields.Many2one(
         related="analytic_account_id.project_analytic_id", readonly=True, store=True

--- a/project_wbs/view/project_project_view.xml
+++ b/project_wbs/view/project_project_view.xml
@@ -109,10 +109,6 @@
                 <field name="account_class" string="Class" />
                 <field name="child_ids" invisible="True" />
             </field>
-            <field name="user_id" position="after">
-                <field name="date_start" string="Start Date" />
-                <field name="date" string="End Date" />
-            </field>
         </field>
     </record>
 


### PR DESCRIPTION
2 fixes:

- the view:

![image](https://github.com/OCA/project/assets/19620251/4c92ac3b-db71-4c4a-8a53-511a6eacf505)

- wbs complete code and indent consistency:

make computed fields in analytic account not editable from the project That can cause data corruption between the project and the analytic account, in case a change is needed in the project the master data in the analytic account should change instead, that is, the code and the parent_id fields. For example, I have a project P1 and a child 01. The complete wbs code of the child is P1 / 01. If I change the complete wbs code in the child to be XXX the complete wbs code of the parent is still P1 but the complete wbs code of the child would be XXX and the code in the child analytic account will still be 01. That is not consistent.

@ForgeFlow