### PR TITLE
[16.0][FIX] project_timeline: Remove redundant view

### DIFF
--- a/project_timeline/readme/CONTRIBUTORS.rst
+++ b/project_timeline/readme/CONTRIBUTORS.rst
@@ -12,3 +12,7 @@
 * `Open Source Integrators <https://www.opensourceintegrators.com>`_:
 
   * Daniel Reis <dreis@opensourceintegrators.com>
+
+* `XCG Consulting <https://xcg-consulting.fr>`_:
+
+  * Houzéfa Abbasbhay

--- a/project_timeline/views/project_project_view.xml
+++ b/project_timeline/views/project_project_view.xml
@@ -23,15 +23,4 @@
     >
         <field name="view_mode">kanban,timeline,form</field>
     </record>
-    <record id="project_project_form" model="ir.ui.view">
-        <field name="name">project.project.form</field>
-        <field name="model">project.project</field>
-        <field name="inherit_id" ref="project.edit_project" />
-        <field name="arch" type="xml">
-            <field name="analytic_account_id" position="before">
-                <field name="date_start" />
-                <field name="date" />
-            </field>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
In Odoo 16, project forms already have these 2 date fields with a nice date-range widget.

The view being removed here adds these date fields at the top of the form (next to an invisible field):

![Screenshot at 2024-01-08 16-06-43](https://github.com/OCA/project/assets/6347423/67cc8fa5-1cf8-4f56-a0e1-66b8d7c6dfb7)
