### PR TITLE
[15.0][FIX] project_wbs: calculation of root analytic account

### DIFF
--- a/project_wbs/models/account_analytic_account.py
+++ b/project_wbs/models/account_analytic_account.py
@@ -106,7 +106,7 @@ class AccountAnalyticAccount(models.Model):
     @api.depends("account_class", "parent_id")
     def _compute_project_analytic_id(self):
         for analytic in self:
-            if analytic.parent_id:
+            if analytic.parent_id.filtered(lambda l: l.account_class == "project"):
                 current = analytic.parent_id
             else:
                 current = analytic


### PR DESCRIPTION
In case there is no parent project with account_class project we should not take the parent, but use current project. Steps to reproduce:

1. Create a master project account_class = null
2. Create a child project account_class = 'project'
3. The root analytic account is missing, it should be the child project as it is the root project (only project with account class 'project' are considered a project)

cc @ForgeFlow