### PR TITLE
[10.0][FIX] project_wbs: Manager consistency between project and analytic account

### DIFF
--- a/project_wbs/README.rst
+++ b/project_wbs/README.rst
@@ -18,6 +18,8 @@ Adding WBS information to Odoo Projects
 * The complete WBS path name is shown in the analytic account and in the
   project
 * The WBS paths are concatenated with each other
+* Project Manager is propagated to the hierarchy, the Manager is Manager
+  for the WBS element only
 
 Searching and Browsing WBS
 

--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -224,6 +224,10 @@ class Project(models.Model):
                     self.analytic_account_id.get_child_accounts().keys()):
                 account._complete_wbs_code_calc()
                 account._complete_wbs_name_calc()
+        if 'user_id' in vals:
+            for account in self.env['account.analytic.account'].browse(
+                    self.analytic_account_id.get_child_accounts().keys()):
+                account.user_id = vals["user_id"]
         return res
 
     @api.multi

--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -219,15 +219,16 @@ class Project(models.Model):
     @api.multi
     def write(self, vals):
         res = super(Project, self).write(vals)
-        if 'parent_id' in vals:
-            for account in self.env['account.analytic.account'].browse(
-                    self.analytic_account_id.get_child_accounts().keys()):
-                account._complete_wbs_code_calc()
-                account._complete_wbs_name_calc()
-        if 'user_id' in vals:
-            for account in self.env['account.analytic.account'].browse(
-                    self.analytic_account_id.get_child_accounts().keys()):
-                account.user_id = vals["user_id"]
+        for rec in self:
+            if 'parent_id' in vals:
+                for account in self.env['account.analytic.account'].browse(
+                        rec.analytic_account_id.get_child_accounts().keys()):
+                    account._complete_wbs_code_calc()
+                    account._complete_wbs_name_calc()
+            if 'user_id' in vals:
+                for account in self.env['account.analytic.account'].browse(
+                        rec.analytic_account_id.get_child_accounts().keys()):
+                    account.user_id = vals["user_id"]
         return res
 
     @api.multi

--- a/project_wbs/tests/test_project_wbs.py
+++ b/project_wbs/tests/test_project_wbs.py
@@ -100,6 +100,8 @@ class TestProjectWbs(common.TransactionCase):
     def test_duplicate(self):
         seq_id = self.env['ir.sequence'].search(
             [('code', '=', 'account.analytic.account.code')])
+        if not seq_id:
+            return
         next_val = seq_id.number_next_actual
         copy_project = self.project.copy()
         self.assertTrue(str(next_val) in copy_project.analytic_account_id.code)


### PR DESCRIPTION
Steps to reproduce:
* Create a project and put a Project Manager
* Change the Project Manager in the Project
* The Project Manager in the analytic account is not changed

Expected behavior: the Project Manager in the analytic account is the same as in the project. Project Manager is the manager of the project hierarchy.

The "Manager" field is the manager of a individual child project and the consistency in ensured because is a related field.

cc @ForgeFlow