### PR TITLE
[14.0][FIX] project_wbs: Manager consistency between project and analytic account

### DIFF
--- a/project_wbs/README.rst
+++ b/project_wbs/README.rst
@@ -40,6 +40,8 @@ Adding WBS information to Odoo Projects
 * The complete WBS path name is shown in the analytic account and in the
   project
 * The WBS paths are concatenated with each other
+* Project Manager is propagated to the hierarchy, the Manager is Manager
+  for the WBS element only
 
 Searching and Browsing WBS
 

--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -293,6 +293,11 @@ class Project(models.Model):
         if "active" in vals and vals["active"]:
             for project in self.filtered(lambda p: not p.analytic_account_id.active):
                 project.analytic_account_id.active = True
+        if "user_id" in vals:
+            for account in self.env["account.analytic.account"].browse(
+                self.analytic_account_id.get_child_accounts().keys()
+            ):
+                account.user_id = vals["user_id"]
         return res
 
     def action_open_parent_kanban_view(self):

--- a/project_wbs/readme/DESCRIPTION.rst
+++ b/project_wbs/readme/DESCRIPTION.rst
@@ -10,6 +10,8 @@ Adding WBS information to Odoo Projects
 * The complete WBS path name is shown in the analytic account and in the
   project
 * The WBS paths are concatenated with each other
+* Project Manager is propagated to the hierarchy, the Manager is Manager
+  for the WBS element only
 
 Searching and Browsing WBS
 

--- a/project_wbs/static/description/index.html
+++ b/project_wbs/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -382,6 +381,8 @@ project</li>
 <li>The complete WBS path name is shown in the analytic account and in the
 project</li>
 <li>The WBS paths are concatenated with each other</li>
+<li>Project Manager is propagated to the hierarchy, the Manager is Manager
+for the WBS element only</li>
 </ul>
 <p>Searching and Browsing WBS</p>
 <ul class="simple">


### PR DESCRIPTION
Steps to reproduce:
* Create a project and put a Project Manager
* Change the Project Manager in the Project
* The Project Manager in the analytic account is not changed

Expected behavior: the Project Manager in the analytic account is the same as in the project. Project Manager is the manager of the project hierarchy.

The "Manager" field is the manager of a individual child project and the consistency in ensured because is a related field.

cc @ForgeFlow