### PR TITLE
[IMP] project_task_code: enable name search by Task Number

### DIFF
--- a/project_task_code/__manifest__.py
+++ b/project_task_code/__manifest__.py
@@ -11,6 +11,7 @@
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/project",
     "license": "AGPL-3",
+    "maintainers": ["luisg123v"],
     "depends": [
         "project",
     ],

--- a/project_task_code/models/project_task.py
+++ b/project_task_code/models/project_task.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
+from odoo.osv import expression
 
 
 class ProjectTask(models.Model):
@@ -42,3 +43,20 @@ class ProjectTask(models.Model):
             name = "[{}] {}".format(rec.code, task[1])
             new_result.append((rec.id, name))
         return new_result
+
+    @api.model
+    def _name_search(self, name="", args=None, operator="ilike", limit=100):
+        """Allow searching by code by default."""
+        if name and operator in ["=", "ilike", "=ilike", "like", "=like"]:
+            args = (
+                expression.OR([[("code", operator, name)], args])
+                if args
+                # The parent method adds the Name to the search domain. As a
+                # consequence of this action, when the args parameter is empty in the
+                # inherited method, an incomplete OR term must be added. Without this
+                # addition, the search domain would default to using an AND operator.
+                else ["|", ("code", operator, name)]
+            )
+        return super()._name_search(
+            name=name, args=args, operator=operator, limit=limit
+        )

--- a/project_task_code/tests/test_project_task_code.py
+++ b/project_task_code/tests/test_project_task_code.py
@@ -38,3 +38,25 @@ class TestProjectTaskCode(common.TransactionCase):
         )
         result = project_task.name_get()
         self.assertEqual(result[0][1], "[%s] Task Testing Get Name" % code)
+
+    def test_name_search(self):
+        number_next = self.task_sequence.number_next_actual
+        code = self.task_sequence.get_next_char(number_next)
+        project_task = self.project_task_model.create(
+            {
+                "name": "Task Testing Name Search",
+            }
+        )
+        result = project_task.name_search(name=code)
+        self.assertEqual(result[0][0], project_task.id)
+
+    def test_name_search_args_none(self):
+        number_next = self.task_sequence.number_next_actual
+        code = self.task_sequence.get_next_char(number_next)
+        project_task = self.project_task_model.create(
+            {
+                "name": "Task Testing Name Search",
+            }
+        )
+        result = project_task.name_search(name=code, args=None)
+        self.assertEqual(result[0][0], project_task.id)


### PR DESCRIPTION
The search functionality has been improved to include the Task Number.
This enhancement is achieved by inheriting the _name_search method to
include the Task Number in the search domain.

The parent method adds the Name to the search domain (1). As a
consequence of this action, when the args parameter is empty in the
inherited method, an incomplete OR term must be added. Without this
addition, the search domain would default to using an AND operator.

Additionally, tests have been added for this new inheritance.

(1) https://github.com/odoo/odoo/blob/4625cb2f/odoo/models.py#L1928