### PR TITLE
[16.0][FIX] project_timeline: Fix unassigned task color

### DIFF
--- a/project_timeline/views/project_task_view.xml
+++ b/project_timeline/views/project_task_view.xml
@@ -15,7 +15,7 @@
                 date_stop="date_end"
                 default_group_by="project_id"
                 event_open_popup="true"
-                colors="white: user_ids == []; #2ecb71: kanban_state == 'done'; #ec7063: kanban_state == 'blocked'"
+                colors="white: user_ids == ''; #2ecb71: kanban_state == 'done'; #ec7063: kanban_state == 'blocked'"
                 dependency_arrow="depend_on_ids"
             >
                 <field name="user_ids" />


### PR DESCRIPTION
Unassigned tasks are supposed to show up in white instead of default color, but the previous `== []` comparison is no longer working in Odoo 16 / with web_timeline 16.0.1.0.3.

This is because web_timeline [forces string conversion](https://github.com/OCA/web/blob/16.0/web_timeline/static/src/js/timeline_renderer.js#L515) during evaluation of these color instructions, and an empty `user_ids` is an empty string in this case.

This does look somewhat odd but fixes the issue short of rewriting py-eval instructions in web_timeline, which would be a much larger task.

# Before

![Screenshot at 2024-03-18 18-26-20](https://github.com/OCA/project/assets/6347423/5e733341-0c3c-4315-bd68-b8a02fea8996)

# After

![Screenshot at 2024-03-18 18-26-47](https://github.com/OCA/project/assets/6347423/8eca10fc-8718-48f8-ad53-396199ce4ed6)

I know the "Unassigned" title on the left seems wrong here (as by default we group per project), but that's another issue.