### PR TITLE
[15.0][FIX] project_wbs: respect the code that user manually puts in the project

### DIFF
--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -145,12 +145,16 @@ class Project(models.Model):
         return None
 
     def prepare_analytics_vals(self, vals):
-        return {
+        analytic_vals = {
             "name": vals.get("name", _("Unknown Analytic Account")),
-            "company_id": vals.get("company_id", self.env.user.company_id.id),
+            "company_id": vals.get("company_id", self.env.company.id),
             "partner_id": vals.get("partner_id"),
             "active": True,
         }
+        code = vals.get("code", False)
+        if code:
+            analytic_vals.update({"code": code})
+        return analytic_vals
 
     def update_project_from_analytic_vals(self, vals):
         new_vals = vals


### PR DESCRIPTION
If the user selects a custom code in the project the analytic account should use the same code.

In order to reproduce just fill the code field in the form view. Without this change, the original code generated with the analytic sequence (ir.sequence) cannot be changed.

cc @ForgeFlow

Lets put an example: 

Create a project, the code is set:
![2024-05-03_14-08](https://github.com/OCA/project/assets/19620251/bb4d88ad-5a2f-40a1-8376-39b19d1d3731)

Then I go to the form view and change the code here:
![2024-05-03_14-09](https://github.com/OCA/project/assets/19620251/494d6ace-fece-419c-938c-8afa997e9a30)

And I expect the code to be set in the project and in the analytic account:

![2024-05-03_14-09_1](https://github.com/OCA/project/assets/19620251/1b51e415-7a6a-4484-867c-b31e36aed3af)

But without this change the code is not set:
![2024-05-03_14-15](https://github.com/OCA/project/assets/19620251/bd3951dc-1eb1-405b-8c16-73581e21cc70)


I checked if the code is not null because there is a constraint that prevents duplicated codes and CI fill fail due to duplicated null codes.
