### PR TITLE
[16.0][IMP] project_timeline: Add date constraint

### DIFF
--- a/project_timeline/models/project_task.py
+++ b/project_timeline/models/project_task.py
@@ -3,13 +3,19 @@
 # Copyright 2021 Open Source Integrators - Daniel Reis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import fields, models
+from odoo import _, api, exceptions, fields, models
 
 
 class ProjectTask(models.Model):
     _inherit = "project.task"
 
     date_start = fields.Datetime("Start Date")
+
+    @api.constrains("date_start", "date_end")
+    def _check_date_start_before_date_end(self):
+        for task in self:
+            if task.date_start and task.date_end and task.date_start > task.date_end:
+                raise exceptions.ValidationError(_("Start Date is after End Date."))
 
     def update_date_end(self, stage_id):
         res = super().update_date_end(stage_id)

--- a/project_timeline/tests/__init__.py
+++ b/project_timeline/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_project_timeline
+from . import test_task_date_constraints

--- a/project_timeline/tests/test_task_date_constraints.py
+++ b/project_timeline/tests/test_task_date_constraints.py
@@ -1,0 +1,20 @@
+from odoo import exceptions, fields
+from odoo.tests.common import TransactionCase
+
+
+class TestTaskDateConstraints(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.task = self.env["project.task"].create({"name": "test"})
+        self.assertFalse(self.task.date_start)
+        self.assertFalse(self.task.date_end)
+
+    def test_valid_dates(self):
+        self.task.date_start = fields.Datetime.today()
+        self.task.date_end = fields.Datetime.add(self.task.date_start, days=1)
+        self.assertGreater(self.task.date_end, self.task.date_start)
+
+    def test_invalid_dates(self):
+        self.task.date_start = fields.Datetime.today()
+        with self.assertRaises(exceptions.ValidationError):
+            self.task.date_end = fields.Datetime.subtract(self.task.date_start, days=1)


### PR DESCRIPTION
Ensure `date_start` (added by this module) is always before `date_end`
(base Odoo field in the `project` module).

Related to https://github.com/OCA/web/pull/2774

This PR comes after https://github.com/OCA/project/pull/1259 (needed to get correct dates)