### PR TITLE
[14.0][FIX] project_wbs: Don't change project.project description

### DIFF
--- a/project_wbs/models/project_project.py
+++ b/project_wbs/models/project_project.py
@@ -10,7 +10,6 @@ from odoo import _, api, fields, models
 
 class Project(models.Model):
     _inherit = "project.project"
-    _description = "WBS element"
     _order = "complete_wbs_code"
 
     analytic_account_id = fields.Many2one(


### PR DESCRIPTION
The change of the project.project model description causes that all the modules in the same repository adopt the new description and export it as the value to translate, making than any instance using one of the modules of OCA/project potentially has this translation, which is catastrophic.

@Tecnativa TT49118