### PR TITLE
[16.0][IMP] project_stock: Add Forecasted Report button to stock moves from tasks

### DIFF
--- a/project_stock/i18n/project_stock.pot
+++ b/project_stock/i18n/project_stock.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-06-07 07:35+0000\n"
+"PO-Revision-Date: 2024-06-07 07:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -124,6 +126,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:project_stock.field_project_task__done_stock_moves
 #: model:ir.model.fields,field_description:project_stock.field_project_task_type__done_stock_moves
 msgid "Done Stock Moves"
+msgstr ""
+
+#. module: project_stock
+#: model_terms:ir.ui.view,arch_db:project_stock.view_stock_move_raw_tree
+msgid "Forecasted Report"
 msgstr ""
 
 #. module: project_stock

--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -99,6 +99,19 @@ class StockMove(models.Model):
             )
         return defaults
 
+    def action_task_product_forecast_report(self):
+        self.ensure_one()
+        action = self.product_id.action_product_forecast_report()
+        action["context"] = {
+            "active_id": self.product_id.id,
+            "active_model": "product.product",
+            "move_to_match_ids": self.ids,
+        }
+        warehouse = self.warehouse_id
+        if warehouse:
+            action["context"]["warehouse"] = warehouse.id
+        return action
+
 
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"

--- a/project_stock/views/stock_move_view.xml
+++ b/project_stock/views/stock_move_view.xml
@@ -42,6 +42,13 @@
                 <field name="state" invisible="1" />
                 <field name="product_uom" groups="uom.group_uom" />
                 <field name="product_uom_qty" string="To Consume" />
+                <button
+                    name="action_task_product_forecast_report"
+                    type="object"
+                    icon="fa-area-chart"
+                    title="Forecasted Report"
+                    attrs="{'invisible': ['|', ('product_id', '=', False),('state', 'in', ['done', 'cancel'])]}"
+                />
                 <field name="product_uom_category_id" invisible="1" />
                 <field
                     name="reserved_availability"


### PR DESCRIPTION
Add Forecasted Report button to stock moves from tasks

![ejemplo](https://github.com/OCA/project/assets/4117568/a24aab96-32f5-46e3-a992-3fa5ab98280c)

@Tecnativa TT47932