### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/project_forecast_line/__manifest__.py
+++ b/project_forecast_line/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Project Forecast Lines",
     "summary": "Project Forecast Lines",
     "version": "14.0.1.0.4",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["ntsirintanis"],
     "license": "AGPL-3",
     "category": "Project",

--- a/project_forecast_line_bokeh_chart/__manifest__.py
+++ b/project_forecast_line_bokeh_chart/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Project Forecast Lines Bokeh Chart",
     "summary": "Project Forecast Lines Bokeh Chart",
     "version": "14.0.1.0.1",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["ntsirintanis"],
     "license": "AGPL-3",
     "category": "Project",


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.