### PR TITLE
[16.0][FIX] project_sequence: Force generate sequence_code when creating project from list view

### DIFF
--- a/project_sequence/models/project_project.py
+++ b/project_sequence/models/project_project.py
@@ -72,7 +72,7 @@ class ProjectProject(models.Model):
         # It is important to set sequence_code before calling super() because
         # other modules such as hr_timesheet expect the name to always have a value
         for vals in vals_list:
-            if "sequence_code" not in vals:
+            if not vals.get("sequence_code", False):
                 vals["sequence_code"] = self.env["ir.sequence"].next_by_code(
                     "project.sequence"
                 )

--- a/project_sequence/tests/test_project_sequence.py
+++ b/project_sequence/tests/test_project_sequence.py
@@ -118,15 +118,34 @@ class TestProjectSequence(TransactionCase):
     @users("manager")
     def test_project_without_sequence(self):
         """Preexisting projects had no sequence, and they should display fine."""
-        proj1 = self.env["project.project"].create(
-            {"name": "one", "sequence_code": False}
+        proj1 = self.env["project.project"].search(
+            [
+                ("sequence_code", "=", False),
+            ],
+            limit=1,
         )
-        self.assertEqual(proj1.display_name, "one")
+        proj1.name = "one"
         self.assertFalse(proj1.sequence_code)
+        self.assertEqual(proj1.display_name, "one")
         # Make sure that the sequence is not increased
         proj2 = self.env["project.project"].create({"name": "two"})
         self.assertEqual(proj2.sequence_code, "23-00011")
         self.assertEqual(proj2.display_name, "23-00011 - two")
+
+    @users("manager")
+    def test_project_with_empty_sequence(self):
+        """Sequence is applied when creating project with an empty sequence"""
+        proj1 = self.env["project.project"].create(
+            {"name": "whatever", "sequence_code": ""}
+        )
+        self.assertEqual(proj1.sequence_code, "23-00011")
+        self.assertEqual(proj1.display_name, "23-00011 - whatever")
+        # Sequence is applied when creating project with sequence in False
+        proj2 = self.env["project.project"].create(
+            {"name": "whatever", "sequence_code": False}
+        )
+        self.assertEqual(proj2.sequence_code, "23-00012")
+        self.assertEqual(proj2.display_name, "23-00012 - whatever")
 
     def test_custom_pattern(self):
         """Display name pattern can be customized."""


### PR DESCRIPTION
When creating a project from the list view, the sequence_code was not generated. These changes fix that problem.