### PR TITLE
[16.0][FIX] project_stock_product_set: Correctly display the wizard in UX

### DIFF
--- a/project_stock_product_set/wizard/project_stock_product_set_wizard_view.xml
+++ b/project_stock_product_set/wizard/project_stock_product_set_wizard_view.xml
@@ -5,7 +5,7 @@
         <field name="model">project.stock.product.set.wizard</field>
         <field name="arch" type="xml">
             <form>
-                <group name="main" colspan="4">
+                <group name="main">
                     <field name="task_id" invisible="context.get('default_task_id')" />
                     <field name="partner_id" invisible="1" />
                     <field
@@ -14,11 +14,11 @@
                     />
                     <field name="quantity" />
                 </group>
-                <group name="lines" colspan="4">
+                <group name="lines">
                     <field
                         name="product_set_line_ids"
                         nolabel="1"
-                        colspan="4"
+                        colspan="2"
                         domain="[('product_set_id', '=', product_set_id)]"
                     >
                         <tree>


### PR DESCRIPTION
Correctly display the wizard in UX

**Before**
![antes](https://github.com/user-attachments/assets/85314a13-2310-4ab3-bfc4-8bd6ae3fa2a5)

**After**
![despues](https://github.com/user-attachments/assets/98f23e3d-407c-436d-9e6b-8787438c0a31)

Please @pedrobaeza and @carolinafernandez-tecnativa can you review it?

@Tecnativa TT50468