### PR TITLE
[16.0][FIX] project_timesheet_time_control: Avoid access error with ir.model

### DIFF
--- a/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py
+++ b/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py
@@ -64,7 +64,7 @@ class HrTimesheetTimeControlMixin(models.AbstractModel):
             self._timesheet_running_domain(),
         )
         if not running_lines:
-            model = self.env["ir.model"].search([("model", "=", self._name)])
+            model = self.env["ir.model"].sudo().search([("model", "=", self._name)])
             message = _(
                 "No running timer found in %(model)s %(record)s. "
                 "Refresh the page and check again."


### PR DESCRIPTION
Avoid access error with ir.model

Only "advanced" users have read access to `ir.model`, for this reason, we need to apply `.sudo()`

Please @pedrobaeza can you review it?

@Tecnativa