### PR TITLE
[14.0][FIX] project_timeline: add fields in report.project.task.user to prevent errors on timeline view

### DIFF
--- a/project_timeline/__init__.py
+++ b/project_timeline/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import models
+from . import report

--- a/project_timeline/report/__init__.py
+++ b/project_timeline/report/__init__.py
@@ -1,0 +1,1 @@
+from . import project_report

--- a/project_timeline/report/project_report.py
+++ b/project_timeline/report/project_report.py
@@ -1,0 +1,28 @@
+# Copyright 2024 Tecnativa - Carlos López
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ReportProjectTaskUser(models.Model):
+    _inherit = "report.project.task.user"
+
+    planned_date_start = fields.Datetime(readonly=True)
+    planned_date_end = fields.Datetime(readonly=True)
+
+    def _select(self):
+        return (
+            super()._select()
+            + """,
+            t.planned_date_start,
+            t.planned_date_end"""
+        )
+
+    def _group_by(self):
+        return (
+            super()._group_by()
+            + """,
+            t.planned_date_start,
+            t.planned_date_end
+            """
+        )


### PR DESCRIPTION
Before this commit, go to `Project > Reporting > Tasks Analysis` and switching to the timeline view would raise an error.

![image](https://github.com/user-attachments/assets/9ea5c847-7b5f-45d0-9d5d-16cb102dff8e)

![image](https://github.com/user-attachments/assets/34bab62d-c6b7-4002-b1a3-0deacc5fe287)


complementary to commit 42bd28c184729eaf07bd7eb399f36049cd31e2af

TT50999
@Tecnativa @pedrobaeza @victoralmau could you please review this