### PR TITLE
[16.0][IMP][project_parent] Hide button box if no children projects

### DIFF
--- a/project_parent/views/project_parent_views.xml
+++ b/project_parent/views/project_parent_views.xml
@@ -16,6 +16,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html). -->
                     class="oe_stat_button"
                     type="object"
                     icon="fa-tasks"
+                    attrs="{'invisible': [('child_ids_count', '=', 0)]}"
                 >
                     <field
                         string="Child Projects"


### PR DESCRIPTION
This PR just adds `attrs="{'invisible': [('child_ids_count', '=', 0)]}"` to the button in project.form's button' box.
This way the button is only visible for projects with children projects, and does not take any space in the button box for project without children.