### PR TITLE
[17.0][FIX] project_timeline: Remove overshadowing of date_end functionality

### DIFF
--- a/project_timeline/models/project_task.py
+++ b/project_timeline/models/project_task.py
@@ -57,11 +57,6 @@ class ProjectTask(models.Model):
                         _("The end date must be after the start date.")
                     )
 
-    def update_date_end(self, stage_id):
-        res = super().update_date_end(stage_id)
-        res.pop("date_end", None)
-        return res
-
     def _auto_init(self):
         # Pre-create and fill planned_date_start and planned_date_end columns for
         # avoiding a costly computation and possible conflicts with the constraint


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/project/pull/1369

Default behaviour of Odoo is to set the date_end if the task moves to a folded stage (e.g. done or cancelled). This method I removed overshadows this functionality, which is not needed anymore because of the new planned dates fields

@Tecnativa