### PR TITLE
[17.0][FIX] project_task_add_very_high: move priority field outside title in sharing project task view form

### DIFF
--- a/project_task_add_very_high/views/project_task_view.xml
+++ b/project_task_add_very_high/views/project_task_view.xml
@@ -11,4 +11,13 @@
             </xpath>
         </field>
     </record>
+    <record id="project_sharing_project_task_view_form" model="ir.ui.view">
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.project_sharing_project_task_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('oe_title')]" position="before">
+                <field name="priority" position="move" />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Before this commit, the priority field was misplaced in the project's sharing project task view form (portal users editable task view). 
<img width="3809" alt="Screenshot 2024-11-29 at 11 17 00" src="https://github.com/user-attachments/assets/e5357fd5-ca7a-48d8-87c8-18eb72915fe5">

After this commit, the exact solution as used in the webclient's project task view form is used for the editable portal view. This solves the misplacement of the field.
<img width="1923" alt="Screenshot 2024-11-29 at 11 11 36" src="https://github.com/user-attachments/assets/c6a7db41-1eaf-455e-b5f3-db3b0c5c9abb">
