### PR TITLE
[FIX] [16.0] project_administrator_restricted_visibility: Restricted Project Manager always can manage its own projects

### DIFF
--- a/project_administrator_restricted_visibility/README.rst
+++ b/project_administrator_restricted_visibility/README.rst
@@ -81,6 +81,7 @@ Contributors
 * `Moduon <https://www.moduon.team>`_:
 
   * Eduardo López
+  * Eduardo de Miguel
 
 Maintainers
 ~~~~~~~~~~~

--- a/project_administrator_restricted_visibility/readme/CONTRIBUTORS.rst
+++ b/project_administrator_restricted_visibility/readme/CONTRIBUTORS.rst
@@ -6,3 +6,4 @@
 * `Moduon <https://www.moduon.team>`_:
 
   * Eduardo López
+  * Eduardo de Miguel

--- a/project_administrator_restricted_visibility/security/project_security.xml
+++ b/project_administrator_restricted_visibility/security/project_security.xml
@@ -9,6 +9,13 @@
             eval="[(3, ref('project.project_project_manager_rule'))]"
         />
     </record>
+    <!-- Restricted Project Manager are allowed to manage its own projects -->
+    <record model="ir.rule" id="project_project_restricted_manage_own_project_rule">
+        <field name="name">Project: Can manage its own projects</field>
+        <field name="model_id" ref="project.model_project_project" />
+        <field name="domain_force">[('user_id', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('project.group_project_manager'))]" />
+    </record>
     <!-- Create a new 'Project Administrator' access group with
     the original 'Project Administrator' access rule for project -->
     <record id="group_full_project_manager" model="res.groups">

--- a/project_administrator_restricted_visibility/static/description/index.html
+++ b/project_administrator_restricted_visibility/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -426,6 +427,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.moduon.team">Moduon</a>:<ul>
 <li>Eduardo López</li>
+<li>Eduardo de Miguel</li>
 </ul>
 </li>
 </ul>
@@ -433,7 +435,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
If you change default visibility to "Invited internal users", Project Administrator with restricted access cannot create projects.

This fix adds a new rule to allow them to create projects always (only create).

Once the project is created, the creator of the projects adds automatically to followers and other rules are applied.

MT-7868 @moduon @rafaelbn @Gelojr @fcvalgar @yajo @ernestotejeda please review if you want 😄 