### PR TITLE
[17.0][IMP] sale_project_task_recurrency: Add options to force month intervals for Quarter and Semester

### DIFF
--- a/sale_project_task_recurrency/models/product_template.py
+++ b/sale_project_task_recurrency/models/product_template.py
@@ -13,6 +13,8 @@ class ProductTemplate(models.Model):
             ("day", "Days"),
             ("week", "Weeks"),
             ("month", "Months"),
+            ("quarter", "Quarters"),
+            ("semester", "Semesters"),
             ("year", "Years"),
         ],
         default="week",
@@ -72,6 +74,27 @@ class ProductTemplate(models.Model):
             ("12", "December"),
         ],
         "Force Month",
+    )
+    task_force_month_quarter = fields.Selection(
+        [
+            ("1", "First month"),
+            ("2", "Second month"),
+            ("3", "Third month"),
+        ],
+        "Force Month",
+        help="Force the month to be used inside the quarter",
+    )
+    task_force_month_semester = fields.Selection(
+        [
+            ("1", "First month"),
+            ("2", "Second month"),
+            ("3", "Third month"),
+            ("4", "Fourth month"),
+            ("5", "Fifth month"),
+            ("6", "Sixth month"),
+        ],
+        "Force Month",
+        help="Force the month to be used inside the semester",
     )
 
     @api.onchange("service_tracking")

--- a/sale_project_task_recurrency/tests/test_product_task_recurrency.py
+++ b/sale_project_task_recurrency/tests/test_product_task_recurrency.py
@@ -330,6 +330,188 @@ class TestProductTaskRecurrency(BaseCommon):
 
     @users("test-user")
     @freeze_time("2024-11-15")
+    def test_task_recurrency_quarter(self):
+        """Every 1 quarter forever"""
+        self.service_task_recurrency.task_repeat_unit = "quarter"
+        self.service_task_recurrency.task_repeat_interval = 1
+        self.sale_order.action_confirm()
+        self.assertFalse(self.sol_no_task.task_id)
+        self.assertFalse(self.sol_task.task_id.recurring_task)
+        task = self.sol_task_recurrency.task_id
+        self.assertTrue(task.recurring_task)
+        # quarter is 3 months
+        self.assertEqual(task.repeat_interval, 3)
+        self.assertEqual(task.repeat_unit, "month")
+        self.assertEqual(task.repeat_type, "forever")
+        self.assertFalse(task.repeat_until)
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-11-15")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-02-15")
+        )
+        # start_date_method = "start_this"
+        # on November, the quarter start on October
+        self.service_task_recurrency.task_start_date_method = "start_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-10-01")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-01-01")
+        )
+        # start_date_method = "end_this"
+        # on November, the quarter ends on December
+        self.service_task_recurrency.task_start_date_method = "end_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-12-31")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-03-31")
+        )
+        # start_date_method = "start_next"
+        # on November, the next quarter starts on January
+        self.service_task_recurrency.task_start_date_method = "start_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-01-01")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-04-01")
+        )
+        # start_date_method = "end_next"
+        self.service_task_recurrency.task_start_date_method = "end_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-03-31")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-06-30")
+        )
+
+    @users("test-user")
+    @freeze_time("2024-11-15")
+    def test_task_recurrency_semester(self):
+        """Every 1 quarter forever"""
+        self.service_task_recurrency.task_repeat_unit = "semester"
+        self.service_task_recurrency.task_repeat_interval = 1
+        self.sale_order.action_confirm()
+        self.assertFalse(self.sol_no_task.task_id)
+        self.assertFalse(self.sol_task.task_id.recurring_task)
+        task = self.sol_task_recurrency.task_id
+        self.assertTrue(task.recurring_task)
+        # semester is 6 months
+        self.assertEqual(task.repeat_interval, 6)
+        self.assertEqual(task.repeat_unit, "month")
+        self.assertEqual(task.repeat_type, "forever")
+        self.assertFalse(task.repeat_until)
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-11-15")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-05-15")
+        )
+        # start_date_method = "start_this"
+        # on November, the semester start on July
+        self.service_task_recurrency.task_start_date_method = "start_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-07-01")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-01-01")
+        )
+        # start_date_method = "end_this"
+        # on November, the semester ends on December
+        self.service_task_recurrency.task_start_date_method = "end_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-12-31")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-06-30")
+        )
+        # start_date_method = "start_next"
+        # on November, the next semester starts on January
+        self.service_task_recurrency.task_start_date_method = "start_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-01-01")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-07-01")
+        )
+        # start_date_method = "end_next"
+        self.service_task_recurrency.task_start_date_method = "end_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-06-30")
+        )
+        self.assertEqual(task.recurring_count, 1)
+        task.state = "1_done"
+        task.invalidate_recordset(["recurring_count"])
+        self.assertEqual(task.recurring_count, 2)
+        last_task = self._get_last_task(task)
+        self.assertEqual(
+            last_task.date_deadline.date(), fields.Date.from_string("2025-12-30")
+        )
+
+    @users("test-user")
+    @freeze_time("2024-11-15")
     def test_task_recurrency_year(self):
         """Every 1 year forever"""
         self.service_task_recurrency.task_repeat_unit = "year"
@@ -746,4 +928,216 @@ class TestProductTaskRecurrency(BaseCommon):
         task = self.sol_task_recurrency.task_id
         self.assertEqual(
             task.date_deadline.date(), fields.Date.from_string("2025-06-30")
+        )
+
+    @users("test-user")
+    @freeze_time("2024-11-15")
+    def test_task_recurrency_quarter_force_month(self):
+        # Force month to firts month of quarter: January, April, July, October
+        self.service_task_recurrency.task_repeat_interval = 1
+        self.service_task_recurrency.task_repeat_unit = "quarter"
+        self.service_task_recurrency.task_force_month_quarter = "1"
+        self.service_task_recurrency.task_repeat_type = "forever"
+        self.sale_order.action_confirm()
+        task = self.sol_task_recurrency.task_id
+        self.assertTrue(task.recurring_task)
+        self.assertEqual(task.repeat_interval, 3)
+        self.assertEqual(task.repeat_unit, "month")
+        self.assertEqual(task.repeat_type, "forever")
+        self.assertEqual(task.recurring_count, 1)
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-10-15")
+        )
+        # start_this
+        self.service_task_recurrency.task_start_date_method = "start_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-10-01")
+        )
+        # end_this
+        self.service_task_recurrency.task_start_date_method = "end_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-10-31")
+        )
+        # start_next
+        self.service_task_recurrency.task_start_date_method = "start_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-01-01")
+        )
+        # end_next
+        self.service_task_recurrency.task_start_date_method = "end_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-01-31")
+        )
+        # Force month to second month of quarter: February, May, August, November
+        self.service_task_recurrency.task_force_month_quarter = "2"
+        self.service_task_recurrency.task_start_date_method = "current_date"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertTrue(task.recurring_task)
+        self.assertEqual(task.repeat_interval, 3)
+        self.assertEqual(task.repeat_unit, "month")
+        self.assertEqual(task.recurring_count, 1)
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-11-15")
+        )
+        # start_this
+        self.service_task_recurrency.task_start_date_method = "start_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-11-01")
+        )
+        # end_this
+        self.service_task_recurrency.task_start_date_method = "end_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-11-30")
+        )
+        # start_next
+        self.service_task_recurrency.task_start_date_method = "start_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-02-01")
+        )
+        # end_next
+        self.service_task_recurrency.task_start_date_method = "end_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-02-28")
+        )
+        # Force month to third month of quarter: March, June, September, December
+        self.service_task_recurrency.task_force_month_quarter = "3"
+        self.service_task_recurrency.task_start_date_method = "current_date"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertTrue(task.recurring_task)
+        self.assertEqual(task.repeat_interval, 3)
+        self.assertEqual(task.repeat_unit, "month")
+        self.assertEqual(task.recurring_count, 1)
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-12-15")
+        )
+        # start_this
+        self.service_task_recurrency.task_start_date_method = "start_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-12-01")
+        )
+        # end_this
+        self.service_task_recurrency.task_start_date_method = "end_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-12-31")
+        )
+        # start_next
+        self.service_task_recurrency.task_start_date_method = "start_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-03-01")
+        )
+        # end_next
+        self.service_task_recurrency.task_start_date_method = "end_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-03-31")
+        )
+
+    @users("test-user")
+    @freeze_time("2024-11-15")
+    def test_task_recurrency_semester_force_month(self):
+        # Force month to second month of semester
+        self.service_task_recurrency.task_repeat_interval = 1
+        self.service_task_recurrency.task_repeat_unit = "semester"
+        self.service_task_recurrency.task_force_month_semester = "2"
+        self.service_task_recurrency.task_repeat_type = "forever"
+        self.sale_order.action_confirm()
+        task = self.sol_task_recurrency.task_id
+        self.assertTrue(task.recurring_task)
+        self.assertEqual(task.repeat_interval, 6)
+        self.assertEqual(task.repeat_unit, "month")
+        self.assertEqual(task.repeat_type, "forever")
+        self.assertEqual(task.recurring_count, 1)
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-08-15")
+        )
+        # start_this
+        self.service_task_recurrency.task_start_date_method = "start_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-08-01")
+        )
+        # end_this
+        self.service_task_recurrency.task_start_date_method = "end_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-08-31")
+        )
+        # start_next
+        self.service_task_recurrency.task_start_date_method = "start_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-02-01")
+        )
+        # end_next
+        self.service_task_recurrency.task_start_date_method = "end_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-02-28")
+        )
+        # Force month to four month of semester
+        self.service_task_recurrency.task_force_month_semester = "4"
+        self.service_task_recurrency.task_start_date_method = "current_date"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertTrue(task.recurring_task)
+        self.assertEqual(task.recurring_count, 1)
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-10-15")
+        )
+        # start_this
+        self.service_task_recurrency.task_start_date_method = "start_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-10-01")
+        )
+        # end_this
+        self.service_task_recurrency.task_start_date_method = "end_this"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2024-10-31")
+        )
+        # start_next
+        self.service_task_recurrency.task_start_date_method = "start_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-04-01")
+        )
+        # end_next
+        self.service_task_recurrency.task_start_date_method = "end_next"
+        self._reprocess_sale_order()
+        task = self.sol_task_recurrency.task_id
+        self.assertEqual(
+            task.date_deadline.date(), fields.Date.from_string("2025-04-30")
         )

--- a/sale_project_task_recurrency/views/product_template_views.xml
+++ b/sale_project_task_recurrency/views/product_template_views.xml
@@ -59,13 +59,23 @@
                 </div>
                 <field
                     name="task_start_date_method"
-                    invisible="not recurring_task or task_repeat_unit not in ['month', 'year']"
+                    invisible="not recurring_task or task_repeat_unit in ['day', 'week']"
                     required="recurring_task"
                     groups="project.group_project_recurring_tasks"
                 />
                 <field
                     name="task_force_month"
                     invisible="task_repeat_unit != 'year'"
+                    groups="project.group_project_recurring_tasks"
+                />
+                <field
+                    name="task_force_month_quarter"
+                    invisible="task_repeat_unit != 'quarter'"
+                    groups="project.group_project_recurring_tasks"
+                />
+                <field
+                    name="task_force_month_semester"
+                    invisible="task_repeat_unit != 'semester'"
                     groups="project.group_project_recurring_tasks"
                 />
             </xpath>


### PR DESCRIPTION

When the task is created, the interval is automatically adjusted to months (3 months for Quarter and 6 months for Semester) since Odoo does not support these options directly.

TT51788 @pedrobaeza could you please review this