### PR TITLE
[FIX] sale_project_copy_tasks: make partner_id field usable in context

### DIFF
--- a/sale_project_copy_tasks/views/sale_order_views.xml
+++ b/sale_project_copy_tasks/views/sale_order_views.xml
@@ -10,6 +10,10 @@
             ref="sale_project.view_order_form_inherit_sale_project"
         />
         <field name="arch" type="xml">
+            <field name="project_id" position="before">
+                <field name="partner_id" invisible="1" />
+            </field>
+
             <xpath expr="//field[@name='project_id']" position="attributes">
                 <attribute name="options">{}</attribute>
                 <attribute


### PR DESCRIPTION
Without this patch, upgrading the addon raises this error:

    Field 'partner_id' used in context ({'default_partner_id': partner_id, 'default_sale_order_id': active_id}) must be present in view but is missing.

<details>

```
2025-01-20 11:08:33,861 1 INFO ? odoo.modules.loading: Loading module sale_project_copy_tasks (277/285) 
2025-01-20 11:08:34,354 1 INFO ? odoo.modules.registry: module sale_project_copy_tasks: creating or updating database tables 
2025-01-20 11:08:34,456 1 INFO ? odoo.schema: Keep unexpected index product_template_message_main_attachment_id_index on table product_template 
2025-01-20 11:08:34,456 1 INFO ? odoo.schema: Keep unexpected index sale_order_message_main_attachment_id_index on table sale_order 
2025-01-20 11:08:34,456 1 INFO ? odoo.schema: Keep unexpected index sale_order_date_order_index on table sale_order 
2025-01-20 11:08:34,456 1 INFO ? odoo.schema: Keep unexpected index product_product_message_main_attachment_id_index on table product_product 
2025-01-20 11:08:34,482 1 INFO ? odoo.modules.loading: loading sale_project_copy_tasks/views/product_template_views.xml 
2025-01-20 11:08:34,501 1 INFO ? odoo.modules.loading: loading sale_project_copy_tasks/views/sale_order_views.xml 
2025-01-20 11:08:34,523 1 DEBUG ? odoo.tools.convert: while parsing /opt/odoo/auto/addons/sale_project_copy_tasks/views/sale_order_views.xml:5
Ocurrió un error al validar vista cercana

<form string="Sales Order" class="o_sale_order">
            <header>
                <field name="authorized_transaction_ids" invisible="1"/>

Field 'partner_id' used in context ({'default_partner_id': partner_id, 'default_sale_order_id': active_id}) must be present in view but is missing.

View error context:
{'file': '/opt/odoo/auto/addons/sale_project_copy_tasks/views/sale_order_views.xml',
 'line': 1,
 'name': 'sale.order.form.inherit.sale.project.copy.tasks',
 'view': ir.ui.view(5814,),
 'view.model': 'sale.order',
 'view.parent': ir.ui.view(3682,),
 'xmlid': 'view_order_form_inherit_sale_project_copy_taks'}
 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 698, in _tag_root
    f(rec)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 599, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4435, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4346, in _load_records_create
    return self.create(values)
  File "<decorator-gen-50>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 558, in create
    result = super(View, self.with_context(ir_ui_view_partial_validation=True)).create(vals_list)
  File "<decorator-gen-68>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_fields.py", line 670, in create
    recs = super().create(vals_list)
  File "<decorator-gen-15>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4002, in create
    records = self._create(data_list)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4254, in _create
    records._validate_fields(name for data in data_list for name in data['stored'])
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1366, in _validate_fields
    check(self)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 476, in _check_xml
    raise err.with_traceback(e.__traceback__) from None
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 450, in _check_xml
    view._validate_view(combined_arch, view.model)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1434, in _validate_view
    validator(node, name_manager, node_info)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1532, in _validate_tag_field
    sub_manager = self._validate_view(
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 1442, in _validate_view
    name_manager.check(self)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 2950, in check
    view._raise_view_error(msg)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 755, in _raise_view_error
    raise err from from_exception
odoo.exceptions.ValidationError: Ocurrió un error al validar vista cercana

<form string="Sales Order" class="o_sale_order">
            <header>
                <field name="authorized_transaction_ids" invisible="1"/>

Field 'partner_id' used in context ({'default_partner_id': partner_id, 'default_sale_order_id': active_id}) must be present in view but is missing.
2025-01-20 11:08:34,531 1 WARNING ? odoo.modules.loading: Transient module states were reset 
2025-01-20 11:08:34,532 1 ERROR ? odoo.modules.registry: Failed to load registry 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/registry.py", line 87, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 485, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 373, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 232, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 72, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 763, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 829, in convert_xml_import
    obj.parse(doc.getroot())
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 749, in parse
    self._tag_root(de)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 709, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /opt/odoo/auto/addons/sale_project_copy_tasks/views/sale_order_views.xml:5
Ocurrió un error al validar vista cercana

<form string="Sales Order" class="o_sale_order">
            <header>
                <field name="authorized_transaction_ids" invisible="1"/>

Field 'partner_id' used in context ({'default_partner_id': partner_id, 'default_sale_order_id': active_id}) must be present in view but is missing.

View error context:
{'file': '/opt/odoo/auto/addons/sale_project_copy_tasks/views/sale_order_views.xml',
 'line': 1,
 'name': 'sale.order.form.inherit.sale.project.copy.tasks',
 'view': ir.ui.view(5814,),
 'view.model': 'sale.order',
 'view.parent': ir.ui.view(3682,),
 'xmlid': 'view_order_form_inherit_sale_project_copy_taks'}
```

</details>

@moduon MT-3426