### PR TITLE
[FIX] sale_project_copy_tasks: find the appropriate `project_id` fiel…

### DIFF
--- a/sale_project_copy_tasks/views/sale_order_views.xml
+++ b/sale_project_copy_tasks/views/sale_order_views.xml
@@ -10,11 +10,10 @@
             ref="sale_project.view_order_form_inherit_sale_project"
         />
         <field name="arch" type="xml">
-            <field name="project_id" position="before">
-                <field name="partner_id" invisible="1" />
-            </field>
-
-            <xpath expr="//field[@name='project_id']" position="attributes">
+            <xpath
+                expr="//group[@name='sale_info']//field[@name='project_id']"
+                position="attributes"
+            >
                 <attribute name="options">{}</attribute>
                 <attribute
                     name="context"


### PR DESCRIPTION
…d always

This reverts https://github.com/OCA/project/pull/1416 and adds instead a different, more accurate fix for the problem (which kept yielding different errors).

The main source of problem is that the same view is adding a `project_id` field and editing another `project_id` fields' attributes. For this reason, installing the module didn't give any problems, but updating it was problematic.

The new field appeared above in the view hierarchy than the old one. The xpath for the old one was less specific than necessary, and then found the new one instead. The new one is within a tree subview, so the model is different (`sale.order.line` instead of `sale.order`). Thus the fields exposed to that field are different, and failures happened a bit randomly.

@moduon MT-3426