### PR TITLE
[16.0][FIX] project_stock: Do not allow to edit specific fields (product, uom, qty) in confirmed moves.

### DIFF
--- a/project_stock/views/stock_move_view.xml
+++ b/project_stock/views/stock_move_view.xml
@@ -23,7 +23,11 @@
                 decoration-danger="state not in ('done', 'cancel') and reserved_availability &lt; product_uom_qty and product_uom_qty - reserved_availability &gt; 0.0001"
             >
                 <field name="company_id" invisible="1" />
-                <field name="product_id" required="1" />
+                <field
+                    name="product_id"
+                    required="1"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
                 <field name="sequence" invisible="1" />
                 <field name="location_id" optional="hide" readonly="1" force_save="1" />
                 <field
@@ -40,8 +44,16 @@
                 />
                 <field name="name" invisible="1" />
                 <field name="state" invisible="1" />
-                <field name="product_uom" groups="uom.group_uom" />
-                <field name="product_uom_qty" string="To Consume" />
+                <field
+                    name="product_uom"
+                    groups="uom.group_uom"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
+                <field
+                    name="product_uom_qty"
+                    string="To Consume"
+                    attrs="{'readonly': [('state', '!=', 'draft')]}"
+                />
                 <button
                     name="action_task_product_forecast_report"
                     type="object"


### PR DESCRIPTION
Do not allow to edit specific fields (product, uom, qty) in confirmed moves.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT54633