### PR TITLE
[14.0][IMP] project_forecast_line: sudo calls updating forecast lines

### DIFF
--- a/project_forecast_line/models/project_task.py
+++ b/project_forecast_line/models/project_task.py
@@ -47,9 +47,9 @@ class ProjectTask(models.Model):
             return res
         self = self.with_context(project_forecast_line_task_noloop=True)
         if "forecast_recomputation_trigger" in values:
-            self._update_forecast_lines()
+            self.sudo()._update_forecast_lines()
         elif "remaining_hours" in values:
-            self._quick_update_forecast_lines()
+            self.sudo()._quick_update_forecast_lines()
         return res
 
     @api.onchange("user_id")


### PR DESCRIPTION
this is necessary to not interfere with ie portal users given permissions to write some fields on tasks