### PR TITLE
[16.0][IMP] project_task_pull_request: Moving PR-URI field

### DIFF
--- a/project_task_pull_request/views/project_task_pull_request_view.xml
+++ b/project_task_pull_request/views/project_task_pull_request_view.xml
@@ -7,10 +7,7 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.view_task_form2" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//page[@name='extra_info']//field[@name='sequence']"
-                position="before"
-            >
+            <xpath expr="//field[@name='user_ids']" position="after">
                 <field name="pr_required_states" attrs="{'invisible':True}" />
                 <field
                     name="pr_uri"


### PR DESCRIPTION
  Moving PR-URI field in the main section of project task form view similar to v14.
  
  Currently in v16, PR URI field is available under "Extra Info" tab which is visible only by activating debug mode.

  So, moving the field to the main section of task form view for ease of visibility and usage.