### PR TITLE
[15.0][FIX] project_timeline: Allow to install this module with project_enterprise

### DIFF
--- a/project_timeline/report/project_report.py
+++ b/project_timeline/report/project_report.py
@@ -8,14 +8,14 @@ class ReportProjectTaskUser(models.Model):
     _inherit = "report.project.task.user"
 
     planned_date_start = fields.Datetime(readonly=True)
-    planned_date_end = fields.Datetime(readonly=True)
+    planned_date_end_custom = fields.Datetime(readonly=True)
 
     def _select(self):
         return (
             super()._select()
             + """,
             t.planned_date_start,
-            t.planned_date_end"""
+            t.planned_date_end AS planned_date_end_custom"""
         )
 
     def _group_by(self):
@@ -23,6 +23,6 @@ class ReportProjectTaskUser(models.Model):
             super()._group_by()
             + """,
             t.planned_date_start,
-            t.planned_date_end
+            t.planned_date_end_custom
             """
         )


### PR DESCRIPTION
This PR fixes an issue added in commit https://github.com/OCA/project/commit/3689f1dfccf755c5d862c0e779ab0364215dea3a

When the module project_timeline is installed in a database with the module project_enterprise, it raises the following error:

```
psycopg2.errors.DuplicateColumn: column "planned_date_end" specified more than once
```

This is because the field planned_date_end is defined in both modules.

This PR checks if the field is already defined in the query before adding it.

Fixes https://github.com/OCA/project/issues/1433