### PR TITLE
[17.0][FIX] project_timesheet_time_control: hide show_time_control column

### DIFF
--- a/project_timesheet_time_control/README.rst
+++ b/project_timesheet_time_control/README.rst
@@ -42,8 +42,8 @@ Installation
 
 This module depends on modules found in these repositories:
 
--  `OCA/timesheet <https://github.com/OCA/timesheet>`__
--  `OCA/web <https://github.com/OCA/web>`__
+- `OCA/timesheet <https://github.com/OCA/timesheet>`__
+- `OCA/web <https://github.com/OCA/web>`__
 
 Usage
 =====
@@ -112,8 +112,8 @@ that belongs to another user.
 Known issues / Roadmap
 ======================
 
--  Rename to ``hr_timesheet_time_control``.
--  Move to `OCA/timesheet <https://github.com/OCA/timesheet>`__.
+- Rename to ``hr_timesheet_time_control``.
+- Move to `OCA/timesheet <https://github.com/OCA/timesheet>`__.
 
 Bug Tracker
 ===========
@@ -136,21 +136,22 @@ Authors
 Contributors
 ------------
 
--  `Tecnativa <https://www.tecnativa.com>`__:
+- `Tecnativa <https://www.tecnativa.com>`__:
 
-      -  Pedro M. Baeza
-      -  Antonio Espinosa
-      -  Carlos Dauden
-      -  Sergio Teruel
-      -  Luis M. ontalba
-      -  Ernesto Tejeda
-      -  Jairo Llopis
-      -  Carlos Roca
+     - Pedro M. Baeza
+     - Antonio Espinosa
+     - Carlos Dauden
+     - Sergio Teruel
+     - Luis M. ontalba
+     - Ernesto Tejeda
+     - Jairo Llopis
+     - Carlos Roca
+     - David Bañón
 
--  `Sygel <https://www.sygel.es>`__:
+- `Sygel <https://www.sygel.es>`__:
 
-      -  Valentín Vinagre
-      -  Roger Sans
+     - Valentín Vinagre
+     - Roger Sans
 
 Maintainers
 -----------

--- a/project_timesheet_time_control/readme/CONTRIBUTORS.md
+++ b/project_timesheet_time_control/readme/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
   > - Ernesto Tejeda
   > - Jairo Llopis
   > - Carlos Roca
+  > - David Bañón
 
 - [Sygel](https://www.sygel.es):
 

--- a/project_timesheet_time_control/static/description/index.html
+++ b/project_timesheet_time_control/static/description/index.html
@@ -496,6 +496,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Ernesto Tejeda</li>
 <li>Jairo Llopis</li>
 <li>Carlos Roca</li>
+<li>David Bañón</li>
 </ul>
 </blockquote>
 </li>

--- a/project_timesheet_time_control/views/account_analytic_line_view.xml
+++ b/project_timesheet_time_control/views/account_analytic_line_view.xml
@@ -12,7 +12,7 @@
                 <field name="date_time_end" optional="hide" />
             </field>
             <field name="unit_amount" position="after">
-                <field name="show_time_control" invisible="1" />
+                <field name="show_time_control" column_invisible="1" />
                 <button
                     name="button_resume_work"
                     tabindex="-1"

--- a/project_timesheet_time_control/views/project_task_view.xml
+++ b/project_timesheet_time_control/views/project_task_view.xml
@@ -9,7 +9,7 @@
             <div name="button_box" position="inside">
                 <field
                     name="show_time_control"
-                    invisible="1"
+                    column_invisible="1"
                     groups="hr_timesheet.group_hr_timesheet_user"
                 />
                 <button
@@ -47,7 +47,7 @@
                 <field name="date_time" string="Date" required="1" />
             </xpath>
             <xpath expr="//field[@name='timesheet_ids']/tree" position="inside">
-                <field name="show_time_control" invisible="1" />
+                <field name="show_time_control" column_invisible="1" />
                 <button
                     name="button_resume_work"
                     title="Resume work"
@@ -200,7 +200,7 @@
             <tree position="inside">
                 <field
                     name="show_time_control"
-                    invisible="1"
+                    column_invisible="1"
                     groups="hr_timesheet.group_hr_timesheet_user"
                 />
                 <button


### PR DESCRIPTION
In odoo 17 tree view now uses column_invisible instead of invisible to hide the entire column.
Before
![image](https://github.com/user-attachments/assets/35e7e1e7-f2b3-4b85-8b7b-49070a892c1d)
![image](https://github.com/user-attachments/assets/dbaec260-46ef-48d5-a2bd-a4eb236230f8)

After
![image](https://github.com/user-attachments/assets/f9b4dec2-094f-439e-8be3-753ef90fd40e)
![image](https://github.com/user-attachments/assets/3b8544df-82e6-4193-9314-447b9c5e529f)



@Tecnativa @pedrobaeza @carlosdauden 
TT55789