### PR TITLE
project_timesheet_time_control : invisible to column_invisible

### DIFF
--- a/project_timesheet_time_control/views/account_analytic_line_view.xml
+++ b/project_timesheet_time_control/views/account_analytic_line_view.xml
@@ -5,14 +5,14 @@
         <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_tree" />
         <field name="arch" type="xml">
             <field name="date" position="attributes">
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </field>
             <field name="date" position="after">
                 <field name="date_time" required="1" />
                 <field name="date_time_end" optional="hide" />
             </field>
             <field name="unit_amount" position="after">
-                <field name="show_time_control" invisible="1" />
+                <field name="show_time_control" column_invisible="1" />
                 <button
                     name="button_resume_work"
                     tabindex="-1"

--- a/project_timesheet_time_control/views/project_project_view.xml
+++ b/project_timesheet_time_control/views/project_project_view.xml
@@ -86,7 +86,7 @@
             <list position="inside">
                 <field
                     name="show_time_control"
-                    invisible="1"
+                    column_invisible="1"
                     groups="hr_timesheet.group_hr_timesheet_user"
                 />
                 <button

--- a/project_timesheet_time_control/views/project_task_view.xml
+++ b/project_timesheet_time_control/views/project_task_view.xml
@@ -38,7 +38,7 @@
                 expr="//field[@name='timesheet_ids']/list//field[@name='date']"
                 position="attributes"
             >
-                <attribute name="invisible">1</attribute>
+                <attribute name="column_invisible">1</attribute>
             </xpath>
             <xpath
                 expr="//field[@name='timesheet_ids']/list//field[@name='date']"
@@ -47,7 +47,7 @@
                 <field name="date_time" string="Date" required="1" />
             </xpath>
             <xpath expr="//field[@name='timesheet_ids']/list" position="inside">
-                <field name="show_time_control" invisible="1" />
+                <field name="show_time_control" column_invisible="1" />
                 <button
                     name="button_resume_work"
                     title="Resume work"
@@ -200,7 +200,7 @@
             <list position="inside">
                 <field
                     name="show_time_control"
-                    invisible="1"
+                    column_invisible="1"
                     groups="hr_timesheet.group_hr_timesheet_user"
                 />
                 <button


### PR DESCRIPTION
Since Odoo 17.0, in tree view, we must use column_invisible instead of invisible : https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-17.0#:~:text=On%20a%20tree%20view%2C%20if%20you%20have%20a%20field

This merge fix this change for project_timesheet_time_control 