### PR TITLE
[16.0][IMP] project_stock: Support for analytical account not accessible byrules

### DIFF
--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -33,6 +33,9 @@ class StockMove(models.Model):
         )
         if not analytic_account:
             return False
+        # Apply sudo() in case there is any rule that does not allow access to
+        # the analytic account, for example with analytic_hr_department_restriction
+        analytic_account = analytic_account.sudo()
         res = {
             "date": (
                 task.stock_analytic_date


### PR DESCRIPTION
Apply `sudo()` in case there is any rule that does not allow access to the analytic account, for example with `analytic_hr_department_restriction`.

Please @pedrobaeza and @pilarvargas-tecnativa can you review it?

@Tecnativa TT55725