### PR TITLE
[17.0][FIX] project_timesheet_time_control: Correctly hide show_time_control in task form

### DIFF
--- a/project_timesheet_time_control/views/project_task_view.xml
+++ b/project_timesheet_time_control/views/project_task_view.xml
@@ -9,7 +9,7 @@
             <div name="button_box" position="inside">
                 <field
                     name="show_time_control"
-                    column_invisible="1"
+                    invisible="1"
                     groups="hr_timesheet.group_hr_timesheet_user"
                 />
                 <button


### PR DESCRIPTION
Hide form field correctly

Before

![image](https://github.com/user-attachments/assets/5f6c4de8-9175-41cb-b979-d1723c730db0)

After

![image](https://github.com/user-attachments/assets/5fbfa6f8-2790-4452-8145-a0b8d4c461f3)

@CarlosRoca13 @david-banon-tecnativa @victoralmau please review