### PR TITLE
[17.0][IMP] project_timesheet_time_control: default start date configurable and improved time calculation

### DIFF
--- a/project_timesheet_time_control/README.rst
+++ b/project_timesheet_time_control/README.rst
@@ -42,8 +42,8 @@ Installation
 
 This module depends on modules found in these repositories:
 
-- `OCA/timesheet <https://github.com/OCA/timesheet>`__
-- `OCA/web <https://github.com/OCA/web>`__
+-  `OCA/timesheet <https://github.com/OCA/timesheet>`__
+-  `OCA/web <https://github.com/OCA/web>`__
 
 Usage
 =====
@@ -112,8 +112,8 @@ that belongs to another user.
 Known issues / Roadmap
 ======================
 
-- Rename to ``hr_timesheet_time_control``.
-- Move to `OCA/timesheet <https://github.com/OCA/timesheet>`__.
+-  Rename to ``hr_timesheet_time_control``.
+-  Move to `OCA/timesheet <https://github.com/OCA/timesheet>`__.
 
 Bug Tracker
 ===========
@@ -136,22 +136,26 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-     - Pedro M. Baeza
-     - Antonio Espinosa
-     - Carlos Dauden
-     - Sergio Teruel
-     - Luis M. ontalba
-     - Ernesto Tejeda
-     - Jairo Llopis
-     - Carlos Roca
-     - David Bañón
+      -  Pedro M. Baeza
+      -  Antonio Espinosa
+      -  Carlos Dauden
+      -  Sergio Teruel
+      -  Luis M. ontalba
+      -  Ernesto Tejeda
+      -  Jairo Llopis
+      -  Carlos Roca
+      -  David Bañón
 
-- `Sygel <https://www.sygel.es>`__:
+-  `Sygel <https://www.sygel.es>`__:
 
-     - Valentín Vinagre
-     - Roger Sans
+      -  Valentín Vinagre
+      -  Roger Sans
+
+-  `glueckkanja ag <https://www.glueckkanja.com>`__:
+
+      -  Christopher Rogos
 
 Maintainers
 -----------

--- a/project_timesheet_time_control/__manifest__.py
+++ b/project_timesheet_time_control/__manifest__.py
@@ -19,6 +19,7 @@
         "views/account_analytic_line_view.xml",
         "views/project_project_view.xml",
         "views/project_task_view.xml",
+        "views/res_config_settings_view.xml",
         "wizards/hr_timesheet_switch_view.xml",
     ],
     "license": "AGPL-3",

--- a/project_timesheet_time_control/i18n/project_timesheet_time_control.pot
+++ b/project_timesheet_time_control/i18n/project_timesheet_time_control.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-29 15:09+0000\n"
+"PO-Revision-Date: 2025-04-29 15:09+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -55,6 +57,11 @@ msgid ""
 msgstr ""
 
 #. module: project_timesheet_time_control
+#: model:ir.model.fields.selection,name:project_timesheet_time_control.selection__res_config_settings__timesheet_alignment__no-gap
+msgid "Align to previous entry"
+msgstr ""
+
+#. module: project_timesheet_time_control
 #: model:ir.model,name:project_timesheet_time_control.model_account_analytic_line
 msgid "Analytic Line"
 msgstr ""
@@ -74,8 +81,18 @@ msgid ""
 msgstr ""
 
 #. module: project_timesheet_time_control
+#: model:ir.model.fields,help:project_timesheet_time_control.field_res_config_settings__timesheet_alignment
+msgid "Choose the alignment of new timesheet entries without start time."
+msgstr ""
+
+#. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_switch__company_id
 msgid "Company"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model,name:project_timesheet_time_control.model_res_config_settings
+msgid "Config Settings"
 msgstr ""
 
 #. module: project_timesheet_time_control
@@ -204,6 +221,11 @@ msgid "Resume work"
 msgstr ""
 
 #. module: project_timesheet_time_control
+#: model:ir.model.fields.selection,name:project_timesheet_time_control.selection__res_config_settings__timesheet_alignment__now
+msgid "Set Start Date to Now"
+msgstr ""
+
+#. module: project_timesheet_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_account_analytic_line__show_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_hr_timesheet_time_control_mixin__show_time_control
 #: model:ir.model.fields,field_description:project_timesheet_time_control.field_project_project__show_time_control
@@ -227,6 +249,11 @@ msgstr ""
 #. module: project_timesheet_time_control
 #: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.hr_timesheet_switch_form
 msgid "Start new timer"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.res_config_settings_view_form
+msgid "Start the next entry now or without a gap to the previous one."
 msgstr ""
 
 #. module: project_timesheet_time_control
@@ -293,6 +320,21 @@ msgstr ""
 #. module: project_timesheet_time_control
 #: model:ir.model.fields,help:project_timesheet_time_control.field_hr_timesheet_switch__running_timer_id
 msgid "This timer is running and will be stopped"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model_terms:ir.ui.view,arch_db:project_timesheet_time_control.res_config_settings_view_form
+msgid "Time Connecting"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_res_config_settings__timesheet_alignment
+msgid "Timesheet Alignment"
+msgstr ""
+
+#. module: project_timesheet_time_control
+#: model:ir.model.fields,field_description:project_timesheet_time_control.field_account_analytic_line__unit_amount_hours
+msgid "Unit Amount Hours"
 msgstr ""
 
 #. module: project_timesheet_time_control

--- a/project_timesheet_time_control/models/__init__.py
+++ b/project_timesheet_time_control/models/__init__.py
@@ -4,3 +4,4 @@ from . import account_analytic_line
 from . import hr_timesheet_time_control_mixin
 from . import project_project
 from . import project_task
+from . import res_config_settings

--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -1,10 +1,13 @@
 # Copyright 2016 Tecnativa - Antonio Espinosa
 # Copyright 2016 Tecnativa - Sergio Teruel
 # Copyright 2016-2018 Tecnativa - Pedro M. Baeza
+# Copyright 2025 glueckkanja AG - Christopher Rogos
+
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from datetime import datetime
+from datetime import datetime, time, timedelta
 
+import pytz
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
@@ -15,8 +18,63 @@ class AccountAnalyticLine(models.Model):
     _inherit = "account.analytic.line"
     _order = "date_time desc"
 
+    @api.model
+    def _get_default_start_time(self):
+        # Set the default start time according to setting to now
+        # or after the previous entry.
+        params = self.env["ir.config_parameter"].sudo()
+        timesheet_alignment = params.get_param(
+            "project_timesheet_time_control.timesheet_alignment"
+        )
+        # default to now
+        now = fields.Datetime.now()
+        start_time = datetime.combine(
+            now.date(), time(hour=now.hour, minute=now.minute, second=0)
+        )
+        if timesheet_alignment == "now":
+            return start_time
+        defaults = self.default_get(["employee_id", "company_id", "date"])
+        date_day = defaults.get("date", now.date())
+        employee_id = defaults.get(
+            "employee_id",
+            self._context.get("default_employee_id", self.env.user.employee_id.id),
+        )
+        if not employee_id:
+            return start_time
+        # get the last entry of the employee on the same day
+        # (searching for date_time_end would be better, but is not working)
+        analytic_lines = self.env[self._name].search(
+            [
+                ["employee_id", "=", employee_id],
+                ["date", "=", date_day],
+                ["date_time", "!=", False],
+            ],
+            order="date_time desc",
+            limit=1,
+        )
+        if analytic_lines.date_time_end:
+            start_time = analytic_lines.date_time_end
+        if not analytic_lines:
+            # if employee has no analytic_lines at this day,
+            # get the employee calendar and set the start time
+            # to the first interval of the day
+            employee = self.env["hr.employee"].browse(employee_id)
+            if employee.resource_calendar_id:
+                start_date = datetime.combine(
+                    date_day, time(0, tzinfo=pytz.timezone(employee.tz))
+                )
+                end_date = start_date + timedelta(days=1)
+                intervals = employee.resource_calendar_id._work_intervals_batch(
+                    start_date, end_date
+                ).get(False, False)
+                if intervals and intervals._items:
+                    start_time = (
+                        intervals._items[0][0].astimezone(pytz.UTC).replace(tzinfo=None)
+                    )
+        return start_time
+
     date_time = fields.Datetime(
-        string="Start Time", default=fields.Datetime.now, copy=False
+        string="Start Time", default=_get_default_start_time, copy=False
     )
     date_time_end = fields.Datetime(
         string="End Time",
@@ -29,20 +87,67 @@ class AccountAnalyticLine(models.Model):
         help="Indicate which time control button to show, if any.",
     )
 
-    @api.depends("date_time", "unit_amount", "product_uom_id")
+    unit_amount_hours = fields.Float(
+        compute="_compute_unit_amount",
+    )
+
+    @api.model
+    def default_get(self, fields_list):
+        vals = super().default_get(fields_list)
+        if (
+            self._context.get("is_timesheet", False)
+            and "product_uom_id" in fields_list
+            and "product_uom_id" not in vals
+        ):
+            company_id = vals.get("company_id")
+            company = False
+            if company_id:
+                company = self.env["res.company"].browse(company_id)
+            if not company:
+                employee_in_id = vals.get(
+                    "employee_id", self._context.get("default_employee_id", False)
+                )
+                if employee_in_id:
+                    company = self.env["hr.employee"].browse(employee_in_id).company_id
+                else:
+                    company = self.env["res.company"].browse(self.env.company.id)
+
+            if "company_id" in fields_list:
+                vals["company_id"] = company.id
+
+            if company and not vals.get("product_uom_id"):
+                vals["product_uom_id"] = company.project_time_mode_id.id
+
+        return vals
+
+    @api.depends("unit_amount", "product_uom_id", "date_time")
     def _compute_date_time_end(self):
         hour_uom = self.env.ref("uom.product_uom_hour")
         for record in self:
-            if (
-                record.product_uom_id == hour_uom
-                and record.date_time
-                and record.unit_amount
-            ):
+            if record.product_uom_id == hour_uom and record.date_time:
+                # When unit_amount is not set, the date_time_end is updated
                 record.date_time_end = record.date_time + relativedelta(
                     hours=record.unit_amount
                 )
             else:
                 record.date_time_end = record.date_time_end
+
+    @api.depends("product_uom_id", "date_time", "date_time_end")
+    def _compute_unit_amount(self):
+        hour_uom = self.env.ref("uom.product_uom_hour")
+        for record in self:
+            if (
+                record.product_uom_id == hour_uom
+                and record.date_time_end
+                and record.date_time
+            ):
+                # When date_time_end or date_time is not set, the unit_amount is updated
+                record.unit_amount = (
+                    record.date_time_end - record.date_time
+                ).total_seconds() / 3600
+                record.unit_amount_hours = record.unit_amount
+            else:
+                record.unit_amount_hours = 0.0
 
     def _inverse_date_time_end(self):
         hour_uom = self.env.ref("uom.product_uom_hour")
@@ -50,7 +155,7 @@ class AccountAnalyticLine(models.Model):
             if record.product_uom_id == hour_uom:
                 record.unit_amount = (
                     record.date_time_end - record.date_time
-                ).seconds / 3600
+                ).total_seconds() / 3600
 
     @api.model
     def _eval_date(self, vals):

--- a/project_timesheet_time_control/models/res_config_settings.py
+++ b/project_timesheet_time_control/models/res_config_settings.py
@@ -1,0 +1,15 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    timesheet_alignment = fields.Selection(
+        selection=[
+            ("now", "Set Start Date to Now"),
+            ("no-gap", "Align to previous entry"),
+        ],
+        default="now",
+        config_parameter="project_timesheet_time_control.timesheet_alignment",
+        help="Choose the alignment of new timesheet entries without start time.",
+    )

--- a/project_timesheet_time_control/readme/CONTRIBUTORS.md
+++ b/project_timesheet_time_control/readme/CONTRIBUTORS.md
@@ -15,3 +15,7 @@
   > - Valentín Vinagre
   > - Roger Sans
 
+- [glueckkanja ag](https://www.glueckkanja.com):
+
+  > - Christopher Rogos
+

--- a/project_timesheet_time_control/static/description/index.html
+++ b/project_timesheet_time_control/static/description/index.html
@@ -508,6 +508,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </blockquote>
 </li>
+<li><p class="first"><a class="reference external" href="https://www.glueckkanja.com">glueckkanja ag</a>:</p>
+<blockquote>
+<ul class="simple">
+<li>Christopher Rogos</li>
+</ul>
+</blockquote>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/project_timesheet_time_control/tests/__init__.py
+++ b/project_timesheet_time_control/tests/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0
 
 from . import test_project_timesheet_time_control
+from . import test_account_analytic_line

--- a/project_timesheet_time_control/tests/test_account_analytic_line.py
+++ b/project_timesheet_time_control/tests/test_account_analytic_line.py
@@ -1,0 +1,167 @@
+from datetime import datetime, timedelta
+
+from freezegun import freeze_time
+
+from odoo import fields
+from odoo.exceptions import UserError
+from odoo.tests.common import TransactionCase
+
+
+class TestAccountAnalyticLine(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.employee = self.env.ref("hr.employee_hne")
+        self.project = self.env.ref("project.project_project_2")
+        self.task = self.env.ref("project.project_2_task_6")
+
+        self.analytic_line_model = self.env["account.analytic.line"]
+        self.uom_hour = self.env.ref("uom.product_uom_hour")
+        self.env["ir.config_parameter"].sudo().set_param(
+            "project_timesheet_time_control.timesheet_alignment", "no-gap"
+        )
+
+    @freeze_time("2025-04-02 12:00:00")
+    def test_get_default_start_time_now(self):
+        """Test the default start time calculation."""
+        self.env["ir.config_parameter"].sudo().set_param(
+            "project_timesheet_time_control.timesheet_alignment", "now"
+        )
+        default_start_time = self.analytic_line_model._get_default_start_time()
+        self.assertEqual(default_start_time, datetime(2025, 4, 2, 12, 0, 0))
+
+    @freeze_time("2025-04-02 12:00:00")
+    def test_get_default_start_time_calendar(self):
+        """Test the default start time calculation."""
+        default_start_time = self.analytic_line_model.with_context(
+            default_employee_id=self.employee.id
+        )._get_default_start_time()
+        self.assertEqual(default_start_time, datetime(2025, 4, 2, 6, 0, 0))
+
+    @freeze_time("2025-04-02 12:00:00")
+    def test_create_by_unit_amount(self):
+        """Test the computation of date_time_end based on unit_amount."""
+        # arrange
+        self.analytic_line_model.create(
+            [
+                {
+                    "name": "Test Line",
+                    "employee_id": self.employee.id,
+                    "date_time": datetime(2025, 4, 2, 14, 0, 0),
+                    "date_time_end": datetime(2025, 4, 2, 15, 0, 0),
+                    "product_uom_id": self.uom_hour.id,
+                },
+                {
+                    "name": "Test Line 2",
+                    "employee_id": self.employee.id,
+                    "date_time": datetime(2025, 4, 2, 12, 0, 0),
+                    "date_time_end": datetime(2025, 4, 2, 13, 0, 0),
+                    "product_uom_id": self.uom_hour.id,
+                },
+            ]
+        )
+        # act
+        analytic_line = self.analytic_line_model.with_context(
+            default_employee_id=self.employee.id
+        ).create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "unit_amount": 2,
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        # assert
+        self.assertEqual(analytic_line.date_time, datetime(2025, 4, 2, 15, 0, 0))
+        self.assertEqual(analytic_line.date_time_end, datetime(2025, 4, 2, 17, 0, 0))
+        self.assertEqual(analytic_line.unit_amount, 2)
+        self.assertEqual(analytic_line.unit_amount_hours, 2)
+
+    def test_compute_date_time_end(self):
+        """Test the computation of date_time_end based on unit_amount."""
+        analytic_line = self.analytic_line_model.create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "date_time": datetime(2025, 4, 2, 12, 0, 0),
+                "unit_amount": 2,
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        self.assertEqual(analytic_line.date_time_end, datetime(2025, 4, 2, 14, 0, 0))
+
+    def test_compute_unit_amount(self):
+        """Test the computation of date_time_end based on unit_amount."""
+        analytic_line = self.analytic_line_model.create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "date_time": datetime(2025, 4, 2, 12, 0, 0),
+                "date_time_end": datetime(2025, 4, 2, 14, 0, 0),
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        self.assertEqual(analytic_line.unit_amount, 2)
+
+    @freeze_time("2025-04-02 12:00:00")
+    def test_button_end_work(self):
+        """Test the button_end_work method."""
+        start_time = fields.Datetime.now()
+        analytic_line = self.analytic_line_model.create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "date_time": start_time,
+                "unit_amount": 0,
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        analytic_line.with_context(
+            stop_dt=start_time + timedelta(hours=2)
+        ).button_end_work()
+        self.assertEqual(analytic_line.unit_amount, 2)
+        self.assertEqual(analytic_line.date_time, datetime(2025, 4, 2, 12, 0, 0))
+
+    def test_button_end_work_error(self):
+        """Test that button_end_work raises an error if the timer is not running."""
+        start_time = fields.Datetime.now()
+        analytic_line = self.analytic_line_model.create(
+            {
+                "name": "Test Line",
+                "employee_id": self.employee.id,
+                "date_time": start_time,
+                "unit_amount": 2,
+                "product_uom_id": self.uom_hour.id,
+            }
+        )
+        with self.assertRaises(UserError):
+            analytic_line.button_end_work()
+
+    def test_running_domain(self):
+        """Test the _running_domain method."""
+        domain = self.analytic_line_model._running_domain()
+        self.assertIn(("date_time", "!=", False), domain)
+        self.assertIn(("user_id", "=", self.env.user.id), domain)
+
+    def test_default_get_with_is_timesheet_context(self):
+        """Test default_get method with is_timesheet context."""
+        company = self.env.company
+        company.project_time_mode_id = self.uom_hour
+
+        # Test with employee and is_timesheet context
+        vals = self.analytic_line_model.with_context(
+            is_timesheet=True, default_employee_id=self.employee.id
+        ).default_get(["product_uom_id", "company_id", "employee_id"])
+        self.assertEqual(vals["product_uom_id"], self.uom_hour.id)
+        self.assertEqual(vals["company_id"], company.id)
+
+        # Test with employee and is_timesheet context
+        vals = self.analytic_line_model.with_context(
+            is_timesheet=True, default_employee_id=self.employee.id
+        ).default_get(["product_uom_id", "employee_id"])
+        self.assertEqual(vals["product_uom_id"], self.uom_hour.id)
+        self.assertNotIn("company_id", vals)
+
+        # Test without employee and is_timesheet context
+        vals = self.analytic_line_model.default_get(["product_uom_id"])
+        self.assertNotIn("product_uom_id", vals)
+        self.assertNotIn("company_id", vals)

--- a/project_timesheet_time_control/views/account_analytic_line_view.xml
+++ b/project_timesheet_time_control/views/account_analytic_line_view.xml
@@ -65,6 +65,9 @@
                 <attribute name="invisible">1</attribute>
             </field>
             <field name="date" position="after">
+                <field name="product_uom_id" invisible="1" />
+                <field name="product_uom_category_id" invisible="1" />
+                <field name="unit_amount_hours" invisible="1" />
                 <field name="date_time" required="1" />
                 <field name="date_time_end" />
             </field>

--- a/project_timesheet_time_control/views/res_config_settings_view.xml
+++ b/project_timesheet_time_control/views/res_config_settings_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.hr.timesheet</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="hr_timesheet.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//block[@name='time_encoding_setting_container']"
+                position="inside"
+            >
+                <setting
+                    string="Time Connecting"
+                    help="Start the next entry now or without a gap to the previous one."
+                >
+                    <field name="timesheet_alignment" widget="radio" />
+                </setting>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
- live value calculation in form. If any of these values is changed, the other are updated accordantly. 
![image](https://github.com/user-attachments/assets/2e834592-f4b7-44cc-8dae-a9e6c836a8ec)

- start date configurable to be "now" or directly "after the previous entry" if available, otherwise use employee working hour as start date
![image](https://github.com/user-attachments/assets/8ff7c933-e254-4b99-943b-992fa8eb8e0c)

@pilarvargas-tecnativa, @david-banon-tecnativa could you please review? Feedback apricated.