### PR TITLE
[16.0][FIX] project_stock: Generate analytical lines in both use cases (tasks and pickings)

### DIFF
--- a/project_stock/models/project_task.py
+++ b/project_stock/models/project_task.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -220,13 +220,7 @@ class ProjectTask(models.Model):
             lambda x: x.state not in ("done", "cancel")
         ):
             move.quantity_done = move.reserved_availability
-        moves_todo = self.mapped("move_ids")._action_done()
-        # Use sudo to avoid error for users with no access to analytic
-        analytic_line_model = self.env["account.analytic.line"].sudo()
-        for move in moves_todo:
-            vals = move._prepare_analytic_line_from_task()
-            if vals:
-                analytic_line_model.create(vals)
+        self.move_ids._action_done()
 
     def action_see_move_scrap(self):
         self.ensure_one()

--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Tecnativa - Víctor Martínez
+# Copyright 2022-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from odoo import api, fields, models
 
@@ -101,6 +101,17 @@ class StockMove(models.Model):
                 }
             )
         return defaults
+
+    def _action_done(self, cancel_backorder=False):
+        """Create the analytical notes for stock movements linked to tasks."""
+        moves_todo = super()._action_done(cancel_backorder)
+        # Use sudo to avoid error for users with no access to analytic
+        analytic_line_model = self.env["account.analytic.line"].sudo()
+        for move in moves_todo.filtered(lambda x: x.raw_material_task_id):
+            vals = move._prepare_analytic_line_from_task()
+            if vals:
+                analytic_line_model.create(vals)
+        return moves_todo
 
     def action_task_product_forecast_report(self):
         self.ensure_one()

--- a/project_stock/tests/test_project_stock.py
+++ b/project_stock/tests/test_project_stock.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2024 Tecnativa - Víctor Martínez
+# Copyright 2022-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from odoo import fields
 from odoo.tests import Form
@@ -77,6 +77,20 @@ class TestProjectStock(TestProjectStockBase):
         self.task.write({"stage_id": self.stage_done.id})
         self.task.action_done()
         self.assertFalse(self.task.stock_analytic_line_ids)
+
+    def test_project_task_picking_done_analytic_items(self):
+        self.task = self.env["project.task"].browse(self.task.id)
+        self.task.action_assign()
+        picking = self.task.move_ids.picking_id
+        for move in picking.move_ids:
+            move.quantity_done = move.product_uom_qty
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+        self._test_task_analytic_lines_from_task(-40)
+        self.assertEqual(
+            fields.first(self.task.stock_analytic_line_ids).date,
+            fields.Date.from_string("1990-01-01"),
+        )
 
     @users("manager-user")
     def test_project_task_without_analytic_account_manager_user(self):


### PR DESCRIPTION
Generate analytical lines in both use cases (tasks and pickings)

In addition to generating the analytical lines at the end of the task, they must also be generated if the pickings is done.

Fixes #1492

Please @pedrobaeza and @etoimene can you review it?

@Tecnativa