### PR TITLE
[18.0][FIX] project_task_stock: Generate analytical lines in both use cases (tasks and pickings)

### DIFF
--- a/project_task_stock/models/project_task.py
+++ b/project_task_stock/models/project_task.py
@@ -231,14 +231,6 @@ class ProjectTask(models.Model):
         ):
             move.quantity = move.product_uom_qty
         moves_to_do.picking_id.with_context(skip_sanity_check=True).button_validate()
-        moves_done = self.move_ids.filtered(lambda x: x.state == "done")
-        moves_todo = moves_done - moves_to_skip
-        # Use sudo to avoid error for users with no access to analytic
-        analytic_line_model = self.env["account.analytic.line"].sudo()
-        for move in moves_todo:
-            vals = move._prepare_analytic_line_from_task()
-            if vals:
-                analytic_line_model.create(vals)
 
     def action_see_move_scrap(self):
         self.ensure_one()

--- a/project_task_stock/tests/test_project_task_stock.py
+++ b/project_task_stock/tests/test_project_task_stock.py
@@ -79,6 +79,20 @@ class TestProjectTaskStock(TestProjectStockBase):
         self.task.action_done()
         self.assertFalse(self.task.sudo().stock_analytic_line_ids)
 
+    def test_project_task_picking_done_analytic_items(self):
+        self.task = self.env["project.task"].browse(self.task.id)
+        self.task.action_assign()
+        picking = self.task.move_ids.picking_id
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty
+        picking.button_validate()
+        self.assertEqual(picking.state, "done")
+        self._test_task_analytic_lines_from_task(-40)
+        self.assertEqual(
+            fields.first(self.task.stock_analytic_line_ids).date,
+            fields.Date.from_string("1990-01-01"),
+        )
+
     @users("manager-user")
     def test_project_task_without_analytic_account_manager_user(self):
         self.test_project_task_without_analytic_account()


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/project/pull/1495

Generate analytical lines in both use cases (tasks and pickings)

In addition to generating the analytical lines at the end of the task, they must also be generated if the pickings is done.

Fixes #1492

Please @pedrobaeza and @etoimene can you review it?

@Tecnativa