### PR TITLE
[16.0][FIX] project_key: consider inactive projects for key uniqueness

### DIFF
--- a/project_key/models/project_project.py
+++ b/project_key/models/project_project.py
@@ -158,13 +158,14 @@ class Project(models.Model):
         return self._generate_project_unique_key("".join(key))
 
     def _generate_project_unique_key(self, text):
+        self_context = self.with_context(active_test=False)
         res = text
         unique_key = False
         counter = 0
         while not unique_key:
             if counter != 0:
                 res = "%s%s" % (text, counter)
-            unique_key = not bool(self.search([("key", "=", res)]))
+            unique_key = not bool(self_context.search([("key", "=", res)]))
             counter += 1
 
         return res
@@ -199,9 +200,7 @@ class Project(models.Model):
         installation.
         :return:
         """
-        for project in self.with_context(active_test=False).search(
-            [("key", "=", False)]
-        ):
+        for project in self.search([("key", "=", False)]):
             project.key = self.generate_project_key(project.name)
             project.create_sequence()
 

--- a/project_key/tests/test_project.py
+++ b/project_key/tests/test_project.py
@@ -69,3 +69,8 @@ class TestProject(TestCommon):
     def test_10_generate_unique_key_with_counter(self):
         project = self.Project.create({"name": "OCA"})
         self.assertEqual(project.key, "OCA1")
+
+    def test_11_generate_unique_key_with_counter_inactive(self):
+        self.project_1.active = False
+        project = self.Project.create({"name": "OCA"})
+        self.assertEqual(project.key, "OCA1")


### PR DESCRIPTION
This small commit fixes a bug where inactive projects would not be considered (on installation or later) when creating a unique key

But the SQL constraint on key uniqueness would still trigger an error later on.