### PR TITLE
[16.0][FIX] project_internal_access_from_portal: access rights

### DIFF
--- a/project_internal_access_from_portal/security/portal_project_rules.xml
+++ b/project_internal_access_from_portal/security/portal_project_rules.xml
@@ -1,7 +1,49 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
 
-    <!-- Portal users see projects if privacy_visibility = portal_internal AND they are followers -->
+    <record id="project.ir_rule_private_task" model="ir.rule">
+        <field name="active" eval="False" />
+    </record>
+
+    <record id="project.report_project_task_user_rule" model="ir.rule">
+        <field name="active" eval="False" />
+    </record>
+
+    <!-- Projects rules for internal users -->
+    <record id="project.project_public_members_rule" model="ir.rule">
+      <field name="name">Internal: Project Visibility</field>
+      <field name="model_id" ref="project.model_project_project" />
+      <field name="domain_force">
+        [
+          '|',
+            ('privacy_visibility', 'not in', ['followers', 'portal_internal']),
+            ('message_partner_ids', 'in', [user.partner_id.id])
+        ]
+      </field>
+      <field name="groups" eval="[(4, ref('base.group_user'))]" />
+    </record>
+
+    <!-- Tasks rules for internal users -->
+    <record id="project.task_visibility_rule" model="ir.rule">
+      <field name="name">Internal: Task Visibility</field>
+      <field name="model_id" ref="project.model_project_task" />
+      <field name="domain_force">
+        [
+          '|',
+            '&amp;',
+              ('project_id', '!=', False),
+              '|',
+                ('project_id.privacy_visibility', 'not in', ['followers', 'portal_internal']),
+                ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+          '|',
+            ('message_partner_ids', 'in', [user.partner_id.id]),
+            ('user_ids', 'in', user.id)
+        ]
+      </field>
+      <field name="groups" eval="[(4, ref('base.group_user'))]" />
+    </record>
+
+  <!-- Portal users see projects if privacy_visibility = portal_internal AND they are followers -->
     <record id="rule_portal_read_internal_projects" model="ir.rule">
       <field name="name">Portal: read invited internal projects</field>
       <field name="model_id" ref="project.model_project_project" />

--- a/project_internal_access_from_portal/tests/test_portal_internal_access.py
+++ b/project_internal_access_from_portal/tests/test_portal_internal_access.py
@@ -75,3 +75,34 @@ class TestPortalInternalAccess(TestAccessRights):
         self.task.flush_model()
         with self.assertRaises(AccessError):
             self.task.with_user(self.portal).unlink()
+
+    def test_internal_user_project_no_read_without_subscription(self):
+        """Internal user cannot read portal_internal project without subscription"""
+        with self.assertRaises(AccessError):
+            _ = self.project_pigs.with_user(self.user).name
+
+    def test_internal_user_project_read_with_subscription(self):
+        """Internal user can read portal_internal project after subscribing"""
+        self.project_pigs.message_subscribe([self.user.partner_id.id])
+        self.env["project.project"].flush_model()
+        _ = self.project_pigs.with_user(self.user).name
+
+    def test_internal_user_task_no_read_without_subscription(self):
+        """Internal user cannot read tasks of portal_internal project without subscription"""
+        with self.assertRaises(AccessError):
+            _ = self.task.with_user(self.user).name
+
+    def test_internal_user_task_read_with_subscription(self):
+        """Internal user can read tasks of portal_internal project after subscribing"""
+        self.project_pigs.message_subscribe([self.user.partner_id.id])
+        self.task.flush_model()
+        _ = self.task.with_user(self.user).name
+
+    def test_internal_user_task_assigned_user_can_read(self):
+        """Internal user can read task if assigned in user_ids"""
+        # Unsubscribe to ensure only assignment grants access
+        self.project_pigs.message_unsubscribe([self.user.partner_id.id])
+        # Assign user to task
+        self.task.write({"user_ids": [(4, self.user.id)]})
+        self.task.flush_model()
+        _ = self.task.with_user(self.user).name


### PR DESCRIPTION
Access rights restriction for base.group_user. Users in this group can only see projects and tasks where they are followers.

Task: 4363.