### PR TITLE
[17.0][IMP] project_hr: restore odoo default user_ids domain

### DIFF
--- a/project_hr/models/project_task.py
+++ b/project_hr/models/project_task.py
@@ -60,7 +60,7 @@ class ProjectTask(models.Model):
     def _compute_allowed_assigned_user_ids(self):
         user_obj = self.env["res.users"]
         for task in self:
-            domain = []
+            domain = [("share", "=", False), ("active", "=", True)]
             if task.hr_category_ids:
                 domain = [
                     (


### PR DESCRIPTION
By default, in Odoo tasks, when you try to assign a user, the field has the domain `[('share', '=', False), ('active', '=', True)]`. However, with this module, a new domain is applied based on the employee category. If no category is selected, all users are shown, which breaks the standard behavior.

With this I restore by default the Odoo domain.