### PR TITLE
[16.0][IMP] project_task_note: improved separation of internal notes section

### DIFF
--- a/project_task_note/views/project_task_views.xml
+++ b/project_task_note/views/project_task_views.xml
@@ -11,12 +11,15 @@
         <field name="inherit_id" ref="project.view_task_form2" />
         <field name="arch" type="xml">
             <field name="description" position="after">
-                <label for="notes" />
+                <div
+                    class="o_horizontal_separator mt-4 mb-3 text-uppercase fw-bolder small"
+                >Internal Notes</div>
                 <field
                     name="notes"
                     nolabel="1"
                     type="html"
                     options="{'collaborative': true, 'resizable': false}"
+                    placeholder="Insert internal notes here"
                 />
             </field>
         </field>


### PR DESCRIPTION
In the task form view, the separation between the description box and the internal notes box is not very clear.

I've improved the internal notes view in order to be better separated from the description box, and also easier to see (lot of times, with a long description, is very hard to quickly find the internal notes section).