### PR TITLE
[16.0][IMP] project_key: improved key visualization

### DIFF
--- a/project_key/models/project_project.py
+++ b/project_key/models/project_project.py
@@ -15,6 +15,8 @@ class Project(models.Model):
 
     key = fields.Char(size=10, required=False, index=True, copy=False)
 
+    show_key_warning = fields.Boolean(store=False, compute="_compute_show_key_warning")
+
     _sql_constraints = [
         ("project_key_unique", "UNIQUE(key)", "Project key must be unique")
     ]
@@ -206,3 +208,7 @@ class Project(models.Model):
 
             for task in project.task_ids:
                 task.key = project.get_next_task_key()
+
+    @api.depends("key")
+    def _compute_show_key_warning(self):
+        self.show_key_warning = self.key and "-" in self.key

--- a/project_key/tests/test_project.py
+++ b/project_key/tests/test_project.py
@@ -74,3 +74,10 @@ class TestProject(TestCommon):
         self.project_1.active = False
         project = self.Project.create({"name": "OCA"})
         self.assertEqual(project.key, "OCA1")
+
+    def test_12_onchange_key(self):
+        project = self.Project.new({"name": "OCA", "key": "TEST"})
+        self.assertFalse(project.show_key_warning)
+
+        project.key = "TEST-1"
+        self.assertTrue(project.show_key_warning)

--- a/project_key/views/project_key_views.xml
+++ b/project_key/views/project_key_views.xml
@@ -9,8 +9,18 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project" />
         <field name="arch" type="xml">
+            <field name="company_id" position="before">
+                <div
+                    class="alert alert-warning"
+                    role="alert"
+                    attrs="{'invisible': [('show_key_warning', '=', False)]}"
+                >
+                    Using '-' in project keys is not recommended.
+                </div>
+            </field>
             <field name="partner_id" position="before">
                 <field name="key" required="1" />
+                <field name="show_key_warning" invisible="1" />
             </field>
         </field>
     </record>
@@ -42,7 +52,8 @@
         <field name="inherit_id" ref="project.view_task_form2" />
         <field name="arch" type="xml">
             <field name="name" position="before">
-                <field name="key" readonly="1" nolabel="1" class="oe_read_only" />
+                <field name="key" readonly="1" nolabel="1" class="oe_inline" />
+                <span class="oe_inline"> : </span>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Added two improvements about `key` field visualization:

1) Due to an obsolete class (`oe_read_only`), key was never displayed near the task title. I deleted the class and now the key is shown correctly:
![immagine](https://github.com/user-attachments/assets/809eb067-9582-45a0-8d2c-5794974fd6c5)

2) I added a warning if in the key there is a dash, because it could work bad with the module itself (e.g. renaming key):
![immagine](https://github.com/user-attachments/assets/27c57753-603d-4e7f-a8ba-90c872f1f851)
