### PR TITLE
[16.0][FIX] project_timesheet_time_control: keep the date when it comes in the creation or writing values.

### DIFF
--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -3,7 +3,7 @@
 # Copyright 2016-2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from datetime import datetime
+from datetime import datetime, time
 
 from dateutil.relativedelta import relativedelta
 
@@ -56,6 +56,8 @@ class AccountAnalyticLine(models.Model):
     def _eval_date(self, vals):
         if vals.get("date_time"):
             return dict(vals, date=self._convert_datetime_to_date(vals["date_time"]))
+        elif vals.get("date"):
+            return dict(vals, date_time=datetime.combine(vals["date"], time(9, 0, 0)))
         return vals
 
     def _convert_datetime_to_date(self, datetime_):

--- a/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -278,3 +278,15 @@ class TestProjectTimesheetTimeControl(common.TransactionCase):
         )
         line.unit_amount = 500.0
         self.assertFalse(line.date_time_end)
+
+    def test_create_timesheet_analytic_line_with_date(self):
+        line = self.env["account.analytic.line"].create(
+            {
+                "date": date(2020, 8, 1),
+                "project_id": self.project.id,
+                "account_id": self.analytic_account.id,
+                "name": "Test non-timesheet line",
+                "product_uom_id": self.env.ref("uom.product_uom_gram").id,
+            }
+        )
+        self.assertEqual(line.date_time, datetime(2020, 8, 1, 9, 0, 0))


### PR DESCRIPTION
There is an inconsistency in the date field and date_time because if a record is created with the date field the date field will have the assigned value, but the date_time will be the current one. For example when requesting Time off with the module Time Off.

To reproduce the error:

1. Create a time off request and approve it.
2. If you go to your timesheet you will see how the date_time that appears is not the date of the time off but the date on which the record has been created. On the other hand, the date field is the correct one. In this case, the date field has to override the date_time field.

<img width="2239" height="1585" alt="image" src="https://github.com/user-attachments/assets/ec29e098-8805-4a8b-b710-6440fa83f238" />

This PR corrects this bug and a test is added to check it.



[T-8520]


