### PR TITLE
[18.0][FIX] project_task_add_very_high: restore standard default task priority

### DIFF
--- a/project_task_add_very_high/models/project_task.py
+++ b/project_task_add_very_high/models/project_task.py
@@ -10,5 +10,4 @@ class ProjectTask(models.Model):
     priority = fields.Selection(
         selection_add=[("2", "Very High"), ("3", "Most Important")],
         ondelete={"priority": "set default"},
-        default="1",
     )

--- a/project_task_add_very_high/tests/test_project_task.py
+++ b/project_task_add_very_high/tests/test_project_task.py
@@ -49,7 +49,7 @@ class TestProjectTaskPriority(BaseCommon):
         """Test updating task priority."""
         # Create a task with a default priority
         task = self.project_task_model.create({"name": "Test Task"})
-        self.assertEqual(task.priority, "1", "Default task priority should be '1'")
+        self.assertEqual(task.priority, "0", "Default task priority should be '0'")
 
         # Update the priority to "Very High"
         task.write({"priority": "2"})


### PR DESCRIPTION
The migration to 18.0 of project_task_add_very_high added an override of the default priority in project.task to "1". This is outside the goal of this module of adding two priority values. One can change the default using ir.default if necessary instead.