### PR TITLE
[16.0][FIX] project_timesheet_time_control: Define the appropriate date if it is a str

### DIFF
--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -57,7 +57,12 @@ class AccountAnalyticLine(models.Model):
         if vals.get("date_time"):
             return dict(vals, date=self._convert_datetime_to_date(vals["date_time"]))
         elif vals.get("date"):
-            return dict(vals, date_time=datetime.combine(vals["date"], time(9, 0, 0)))
+            date_item = (
+                fields.Date.from_string(vals["date"])
+                if isinstance(vals["date"], str)
+                else vals["date"]
+            )
+            return dict(vals, date_time=datetime.combine(date_item, time(9, 0, 0)))
         return vals
 
     def _convert_datetime_to_date(self, datetime_):

--- a/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -279,10 +279,22 @@ class TestProjectTimesheetTimeControl(common.TransactionCase):
         line.unit_amount = 500.0
         self.assertFalse(line.date_time_end)
 
-    def test_create_timesheet_analytic_line_with_date(self):
+    def test_create_timesheet_analytic_line_with_date_01(self):
         line = self.env["account.analytic.line"].create(
             {
                 "date": date(2020, 8, 1),
+                "project_id": self.project.id,
+                "account_id": self.analytic_account.id,
+                "name": "Test non-timesheet line",
+                "product_uom_id": self.env.ref("uom.product_uom_gram").id,
+            }
+        )
+        self.assertEqual(line.date_time, datetime(2020, 8, 1, 9, 0, 0))
+
+    def test_create_timesheet_analytic_line_with_date_02(self):
+        line = self.env["account.analytic.line"].create(
+            {
+                "date": "2020-08-01",
                 "project_id": self.project.id,
                 "account_id": self.analytic_account.id,
                 "name": "Test non-timesheet line",


### PR DESCRIPTION
Define the appropriate date if it is a str

Use case example: install `project_timesheet_time_control` + `sale_timesheet`

Related to https://github.com/OCA/project/commit/3f710c6f85cccfd24eda44bf30b756cba9d43524

Please @pedrobaeza can you review it?

@Tecnativa