### PR TITLE
[16.0][FIX] project_sequence: return proper name_get values in name_search

### DIFF
--- a/project_sequence/models/project_project.py
+++ b/project_sequence/models/project_project.py
@@ -59,12 +59,26 @@ class ProjectProject(models.Model):
 
     @api.model
     def name_search(self, name="", args=None, operator="ilike", limit=100):
-        """Allow searching by sequence code by default."""
-        # Do not add any domain when user just clicked on search widget
-        if not (name == "" and operator == "ilike"):
-            # The dangling | is needed to combine with the domain added by super()
-            args = (args or []) + ["|", ("sequence_code", operator, name)]
-        return super().name_search(name, args, operator, limit)
+        """Allow searching by sequence_code, key, or name and return proper display names."""
+        args = list(args or [])
+        domain = []
+
+        if name and not (name == "" and operator == "ilike"):
+            search_domain = [
+                ("sequence_code", operator, name),
+                ("key", operator, name),
+                ("name", operator, name),
+            ]
+            if name.isdigit():
+                search_domain.append(("id", "=", int(name)))
+
+            if len(search_domain) > 1:
+                domain = ["|"] * (len(search_domain) - 1) + search_domain
+            else:
+                domain = search_domain
+
+        ids = self._search(domain + args, limit=limit)
+        return self.browse(ids).name_get()
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/project_sequence/tests/test_project_sequence.py
+++ b/project_sequence/tests/test_project_sequence.py
@@ -223,3 +223,33 @@ class TestProjectSequence(TransactionCase):
         self.assertIn((proj2.id, "23-00012 - two"), results)
         self.assertNotIn((proj1.id, "23-00011 - one"), results)
         self.assertNotIn((proj3.id, "23-00013 - three"), results)
+
+    def test_name_search_by_key(self):
+        """Allow searching by key field."""
+        proj1 = self.env["project.project"].create({"name": "one", "key": "KEY1"})
+        self.assertEqual(proj1.sequence_code, "23-00011")
+        proj2 = self.env["project.project"].create({"name": "two", "key": "KEY2"})
+        self.assertEqual(proj2.sequence_code, "23-00012")
+        proj3 = self.env["project.project"].create({"name": "three", "key": "KEY3"})
+        self.assertEqual(proj3.sequence_code, "23-00013")
+
+        # Search by key
+        results = self.env["project.project"].name_search("KEY2")
+        self.assertIn((proj2.id, "23-00012 - two"), results)
+        self.assertNotIn((proj1.id, "23-00011 - one"), results)
+        self.assertNotIn((proj3.id, "23-00013 - three"), results)
+
+    def test_name_search_by_id(self):
+        """Allow searching by project ID when input is a digit."""
+        proj1 = self.env["project.project"].create({"name": "one"})
+        self.assertEqual(proj1.sequence_code, "23-00011")
+        proj2 = self.env["project.project"].create({"name": "two"})
+        self.assertEqual(proj2.sequence_code, "23-00012")
+        proj3 = self.env["project.project"].create({"name": "three"})
+        self.assertEqual(proj3.sequence_code, "23-00013")
+
+        # Search by project ID
+        results = self.env["project.project"].name_search(str(proj2.id))
+        self.assertIn((proj2.id, "23-00012 - two"), results)
+        self.assertNotIn((proj1.id, "23-00011 - one"), results)
+        self.assertNotIn((proj3.id, "23-00013 - three"), results)


### PR DESCRIPTION
Fix test case: I faced a test_name_search error while working on this PR → https://github.com/OCA/project/pull/1561

The test expected name_search results to include sequence_code in the display name (e.g. "23-00012 - two").