### PR TITLE
[16.0][IMP] project_key: URL link can redirect to portal

### DIFF
--- a/project_key/__manifest__.py
+++ b/project_key/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "LGPL-3",
     "author": "Modoolar, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/project",
-    "depends": ["project"],
+    "depends": ["portal", "project"],
     "data": ["views/project_key_views.xml"],
     "post_init_hook": "post_init_hook",
 }

--- a/project_key/controllers/main.py
+++ b/project_key/controllers/main.py
@@ -1,41 +1,29 @@
 # Copyright 2017 - 2018 Modoolar <info@modoolar.com>
 # License LGPLv3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
-import werkzeug
 
 from odoo import http
+from odoo.http import request
 
-# from odoo.http import request
+from odoo.addons.portal.controllers.mail import MailController
 
 
 class ProjectBrowser(http.Controller):
-    def get_record_url(self, model, domain, action_xml_id):
-        env = http.request.env()
-
-        records = env[model].search(domain)
-        record_id = records and records.id or -1
-        action_id = env.ref(action_xml_id).id
-
-        return "/web#id={}&view_type=form&model={}&action={}".format(
-            record_id, model, action_id
-        )
+    def get_record_url(self, model, domain):
+        record = request.env[model].sudo().search(domain, limit=1)
+        record_id = record and record.id or 0
+        return MailController._redirect_to_record(model, record_id)
 
     def get_task_url(self, key):
-        return self.get_record_url(
-            "project.task", [("key", "=ilike", key)], "project.action_view_task"
-        )
+        return self.get_record_url("project.task", [("key", "=ilike", key)])
 
     def get_project_url(self, key):
-        return self.get_record_url(
-            "project.project",
-            [("key", "=ilike", key)],
-            "project.open_view_project_all_config",
-        )
+        return self.get_record_url("project.project", [("key", "=ilike", key)])
 
     @http.route(["/projects/<string:key>"], type="http", auth="user")
     def open_project(self, key, **kwargs):
-        return werkzeug.utils.redirect(self.get_project_url(key), 301)
+        return self.get_project_url(key)
 
     @http.route(["/tasks/<string:key>"], type="http", auth="user")
     def open_task(self, key, **kwargs):
-        return werkzeug.utils.redirect(self.get_task_url(key), 301)
+        return self.get_task_url(key)

--- a/project_key/tests/test_common.py
+++ b/project_key/tests/test_common.py
@@ -28,16 +28,10 @@ class TestMixin(object):
 
         self.task30 = self.Task.create({"name": "3"})
 
-    def get_record_url(self, record, model, action):
-        return "/web#id={}&view_type=form&model={}&action={}".format(
-            record.id, model, action
-        )
-
     def get_task_url(self, task):
-        return self.get_record_url(task, task._name, self.task_action.id)
-
-    def get_project_url(self, project):
-        return self.get_record_url(project, project._name, self.project_action.id)
+        return "/web#id={}&view_type=form&model={}&action={}".format(
+            task.id, task._name, self.task_action.id
+        )
 
 
 class TestCommon(TransactionCase, TestMixin):

--- a/project_key/tests/test_controller.py
+++ b/project_key/tests/test_controller.py
@@ -9,14 +9,35 @@ class TestController(HttpTestCommon):
         self.authenticate("admin", "admin")
         response = self.url_open("/projects/" + self.project_1.key)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(
-            response.url.endswith(self.get_project_url(self.project_1)), response.url
-        )
+        self.assertIn("/web#", response.url)
+        self.assertIn(f"model={self.project_1._name}", response.url)
+        self.assertIn(f"id={self.project_1.id}", response.url)
 
     def test_02_task_browse(self):
         self.authenticate("admin", "admin")
         response = self.url_open("/tasks/" + self.task11.key)
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(
-            response.url.endswith(self.get_task_url(self.task11)), response.url
-        )
+        self.assertIn("/web#", response.url)
+        self.assertIn(f"model={self.task11._name}", response.url)
+        self.assertIn(f"id={self.task11.id}", response.url)
+
+    def test_03_project_browse_portal(self):
+        self.authenticate("portal", "portal")
+        response = self.url_open("/projects/" + self.project_1.key)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(f"/my/projects/{self.project_1.id}", response.url)
+
+    def test_04_task_browse_portal(self):
+        portal_partner = self.env.ref("base.demo_user0").partner_id
+        self.authenticate("portal", "portal")
+        project = self.task11.project_id
+        self.assertEqual(project.privacy_visibility, "portal")
+        self.assertNotIn(project.message_partner_ids, portal_partner)
+        response = self.url_open("/tasks/" + self.task11.key)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.url.endswith("/my"))
+
+        project.message_partner_ids += portal_partner
+        response = self.url_open("/tasks/" + self.task11.key)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f"/my/tasks/{self.task11.id}", response.url)


### PR DESCRIPTION
Simple fix to reuse the existing feature from the `portal` module instead of manually building the URL. As a bonus, portal users can now also use the same link.

(I'm working on another PR to also display the key on the portal EDIT: #1581 )