### PR TITLE
[18.0][IMP] project_tag*: Remove auto_install=True

### DIFF
--- a/project_tag_hierarchy/README.rst
+++ b/project_tag_hierarchy/README.rst
@@ -56,10 +56,10 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Víctor Martínez
-  - Pedro M. Baeza
+   -  Víctor Martínez
+   -  Pedro M. Baeza
 
 Maintainers
 -----------

--- a/project_tag_hierarchy/__manifest__.py
+++ b/project_tag_hierarchy/__manifest__.py
@@ -9,7 +9,6 @@
     "license": "AGPL-3",
     "depends": ["project"],
     "installable": True,
-    "auto_install": True,
     "data": [
         "views/project_tags_views.xml",
     ],

--- a/project_tag_multicompany/README.rst
+++ b/project_tag_multicompany/README.rst
@@ -57,10 +57,10 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Víctor Martínez
-  - Pedro M. Baeza
+   -  Víctor Martínez
+   -  Pedro M. Baeza
 
 Maintainers
 -----------

--- a/project_tag_multicompany/__manifest__.py
+++ b/project_tag_multicompany/__manifest__.py
@@ -9,7 +9,6 @@
     "license": "AGPL-3",
     "depends": ["project"],
     "installable": True,
-    "auto_install": True,
     "data": [
         "security/project_tags_security.xml",
         "views/project_tags_views.xml",

--- a/project_tag_security/README.rst
+++ b/project_tag_security/README.rst
@@ -68,10 +68,10 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Víctor Martínez
-  - Pedro M. Baeza
+   -  Víctor Martínez
+   -  Pedro M. Baeza
 
 Maintainers
 -----------

--- a/project_tag_security/__manifest__.py
+++ b/project_tag_security/__manifest__.py
@@ -9,7 +9,6 @@
     "license": "AGPL-3",
     "depends": ["project"],
     "installable": True,
-    "auto_install": True,
     "data": [
         "views/project_tags_views.xml",
     ],


### PR DESCRIPTION
Remove auto_install=True to `project_tag_hierarchy`, `project_tag_multicompany` and `project_tag_security`.

Related to https://github.com/OCA/project/pull/1449#issuecomment-3411217883

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa