### PR TITLE
[ADD] simplify onChange and remove user_ids, tag

### DIFF
--- a/project_task_description_template/models/project_task.py
+++ b/project_task_description_template/models/project_task.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2023 Cetmix OÜ
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/lgpl)
+import re
 
 from odoo import api, fields, models
 
@@ -36,9 +37,13 @@ class ProjectTask(models.Model):
     @api.onchange("task_template_id")
     def _onchange_task_template_id(self):
         if self.task_template_id:
-            description = self.description if self.description else ""
+            description = self.description or ""
+            template_desc = self.task_template_id.description or ""
+            # Avoid multiple template additions when multiple onchanges are triggered
+            if not re.search(rf"{re.escape(template_desc)}", description):
+                description += template_desc
             update_dict = {
-                "description": description + self.task_template_id.description,
+                "description": description,
             }
             if self.task_template_id.tag_ids:
                 update_dict["tag_ids"] = self.task_template_id.tag_ids.ids

--- a/project_task_description_template/models/project_task.py
+++ b/project_task_description_template/models/project_task.py
@@ -36,10 +36,12 @@ class ProjectTask(models.Model):
     @api.onchange("task_template_id")
     def _onchange_task_template_id(self):
         if self.task_template_id:
-            self.update(
-                {
-                    "user_id": self.task_template_id.user_id.id,
-                    "tag_ids": self.task_template_id.tag_ids.ids,
-                    "description": self.task_template_id.description,
-                }
-            )
+            description = self.description if self.description else ""
+            update_dict = {
+                "description": description + self.task_template_id.description,
+                "tag_ids": self.task_template_id.tag_ids.ids,
+            }
+            # trigger write on user only if in template.
+            if self.task_template_id.user_id:
+                update_dict["user_id"] = self.task_template_id.user_id.id
+            self.update(update_dict)

--- a/project_task_description_template/models/project_task.py
+++ b/project_task_description_template/models/project_task.py
@@ -39,8 +39,9 @@ class ProjectTask(models.Model):
             description = self.description if self.description else ""
             update_dict = {
                 "description": description + self.task_template_id.description,
-                "tag_ids": self.task_template_id.tag_ids.ids,
             }
+            if self.task_template_id.tag_ids:
+                update_dict["tag_ids"] = self.task_template_id.tag_ids.ids
             # trigger write on user only if in template.
             if self.task_template_id.user_id:
                 update_dict["user_id"] = self.task_template_id.user_id.id

--- a/project_task_description_template/tests/test_task_template.py
+++ b/project_task_description_template/tests/test_task_template.py
@@ -58,12 +58,8 @@ class TestProjectTaskTemplate(SavepointCase):
         )
         cls.template_3 = task_template_model.create(
             {
-                "name": "Template3 - no user",
-                "tag_ids": [
-                    cls.tag_blue.id,
-                    cls.tag_white.id,
-                ],
-                "description": "This is template 3 - no user_id",
+                "name": "Template3 - no user, no tags",
+                "description": "This is template 3 - no user_id, no tags",
             }
         )
         # create project model
@@ -254,6 +250,7 @@ class TestProjectTaskTemplate(SavepointCase):
             self.test_task_1.description if self.test_task_1.description else ""
         )
         prev_user_id = self.test_task_1.user_id
+        prev_tag_ids = self.test_task_1.tag_ids.ids
         # Set the task_template_id of test_task_1 to template_3.id,
         self.test_task_1.task_template_id = self.template_3.id
         # Trigger the _onchange_task_template_id method
@@ -269,8 +266,8 @@ class TestProjectTaskTemplate(SavepointCase):
         # Verify that the tag_ids of test_task_1 are equal to the tag_ids of template_3
         self.assertEqual(
             self.test_task_1.tag_ids.ids,
-            self.template_3.tag_ids.ids,
-            msg="The task 1 tag IDs must be equal to the template 1 tag IDs",
+            prev_tag_ids,
+            msg="The task 1 tags must remain unchanged",
         )
 
         # Verify that the description of test_task_1 is

--- a/project_task_description_template/tests/test_task_template.py
+++ b/project_task_description_template/tests/test_task_template.py
@@ -56,6 +56,16 @@ class TestProjectTaskTemplate(SavepointCase):
                 "description": "This is template 2",
             }
         )
+        cls.template_3 = task_template_model.create(
+            {
+                "name": "Template3 - no user",
+                "tag_ids": [
+                    cls.tag_blue.id,
+                    cls.tag_white.id,
+                ],
+                "description": "This is template 3 - no user_id",
+            }
+        )
         # create project model
         project_model = cls.env["project.project"]
         # create projects : "Project 1" and add templates 1-2
@@ -105,8 +115,11 @@ class TestProjectTaskTemplate(SavepointCase):
     def test_task_1_template_1(self):
         """Test the behavior when choosing a template."""
         # Set the task_template_id of test_task_1 to template_1.id
+        prev_description = (
+            self.test_task_1.description if self.test_task_1.description else ""
+        )
         self.test_task_1.task_template_id = self.template_1.id
-
+        # saving previous description
         # Trigger the _onchange_task_template_id method
         self.test_task_1._onchange_task_template_id()
 
@@ -129,12 +142,16 @@ class TestProjectTaskTemplate(SavepointCase):
         # equal to the description of template_1
         self.assertEqual(
             self.test_task_1.description,
-            self.template_1.description,
-            msg="The task 1 description must be equal to the template 1 description",
+            prev_description + self.template_1.description,
+            msg="The task 1 desc must be = to '%s' with template 1 desc appended"
+            % prev_description,
         )
 
     def test_task_1_template_2(self):
         """Test the behavior when choosing a different template (template_2)."""
+        prev_description = (
+            self.test_task_1.description if self.test_task_1.description else ""
+        )
         # Set the task_template_id of test_task_1 to template_2.id
         self.test_task_1.task_template_id = self.template_2.id
 
@@ -160,14 +177,18 @@ class TestProjectTaskTemplate(SavepointCase):
         # equal to the description of template_2
         self.assertEqual(
             self.test_task_1.description,
-            self.template_2.description,
-            msg="The task 1 description must be equal to the template 2 description",
+            prev_description + self.template_2.description,
+            msg="The task 1 desc must be = to '%s' with template 2 desc appended"
+            % prev_description,
         )
 
     def test_task_1_template_false(self):
         """Test the behavior when setting task_template_id to False
         after choosing a template.
         """
+        prev_description = (
+            self.test_task_1.description if self.test_task_1.description else ""
+        )
         # Set the task_template_id of test_task_1 to template_2.id
         self.test_task_1.task_template_id = self.template_2.id
 
@@ -200,8 +221,9 @@ class TestProjectTaskTemplate(SavepointCase):
         # equal to the description of template_2
         self.assertEqual(
             self.test_task_1.description,
-            self.template_2.description,
-            msg="The task 1 description must be equal to the template 2 description",
+            prev_description + self.template_2.description,
+            msg="The task 1 desc must be = to '%s' with template 2 desc appended"
+            % prev_description,
         )
 
     def test_task_2_template_2(self):
@@ -224,6 +246,41 @@ class TestProjectTaskTemplate(SavepointCase):
         self.project_2.task_template_ids = [self.template_1.id]
         self.project_2._onchange_task_template_ids()
         self.assertFalse(self.project_2.default_task_template_id, msg="Must be empty")
+
+    def test_task_1_template_3(self):
+        """Test the behavior when choosing a template without user_id."""
+        # saving previous description
+        prev_description = (
+            self.test_task_1.description if self.test_task_1.description else ""
+        )
+        prev_user_id = self.test_task_1.user_id
+        # Set the task_template_id of test_task_1 to template_3.id,
+        self.test_task_1.task_template_id = self.template_3.id
+        # Trigger the _onchange_task_template_id method
+        self.test_task_1._onchange_task_template_id()
+        # Verify that the user_id of test_task_1 has remained the same.
+        # template3 has nor user_id and should not override or cancel user_id
+        self.assertEqual(
+            self.test_task_1.user_id.id,
+            prev_user_id.id,
+            msg="The task 1 user #id must be unchanged, template 3 has no user_id",
+        )
+
+        # Verify that the tag_ids of test_task_1 are equal to the tag_ids of template_3
+        self.assertEqual(
+            self.test_task_1.tag_ids.ids,
+            self.template_3.tag_ids.ids,
+            msg="The task 1 tag IDs must be equal to the template 1 tag IDs",
+        )
+
+        # Verify that the description of test_task_1 is
+        # equal to the description of template_3
+        self.assertEqual(
+            self.test_task_1.description,
+            prev_description + self.template_3.description,
+            msg="The task 1 desc must be = to '%s' with template 1 desc appended"
+            % prev_description,
+        )
 
     def test_change_stage(self):
         """Test the behavior when changing the stage of a task."""


### PR DESCRIPTION
changing  the 14.0 version of the module,  to make it more similar to former versions.
User_id and tag_ids will not overwrite existing user and tags if left empty on template, therefore mirroring behaviour of  v15-v18.  
They will still work, for legacy users (user_id and tag_ids was removed from v15-v18).

Description will be appended. As it is done in v15-v18 versions.

tests updated. new tests for empty user_id, empty tag_ids cases.
 