### PR TITLE
[18.0][IMP] project_timesheet_time_control: sync unit_amount with date_time and date_time_end on form view

### DIFF
--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -54,6 +54,13 @@ class AccountAnalyticLine(models.Model):
 
     @api.model
     def _eval_date(self, vals):
+        if vals.get("date") and not vals.get("date_time"):
+            return dict(
+                vals,
+                date_time=datetime.combine(
+                    fields.Date.to_date(vals["date"]), fields.Datetime.now().time()
+                ),
+            )
         if vals.get("date_time"):
             return dict(vals, date=self._convert_datetime_to_date(vals["date_time"]))
         return vals
@@ -110,35 +117,33 @@ class AccountAnalyticLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        for vals in vals_list:
-            if "date" in vals and "date_time" not in vals:
-                date = fields.Date.to_date(vals["date"])
-                vals["date_time"] = datetime.combine(date, fields.Datetime.now().time())
         return super().create(list(map(self._eval_date, vals_list)))
 
     def write(self, vals):
+        self_individual = self.env["account.analytic.line"]
+        res_individual = True
         if "date" in vals and "date_time" not in vals:
-            res = super(
-                AccountAnalyticLine, self.filtered(lambda r: not r.date_time)
-            ).write(vals)
-
-            # only overwrite the date part of date_time
-            for record in self.filtered(lambda r: r.date_time):
+            self_individual = self.filtered(lambda r: r.date_time)
+            # overwrite the date part of date_time for each record
+            for record in self_individual:
                 vals["date_time"] = fields.Datetime.to_string(
                     datetime.combine(
                         fields.Date.to_date(vals["date"]),
                         record.date_time.time(),
                     )
                 )
-                res |= super(AccountAnalyticLine, record).write(vals)
-            return res
-        else:
-            return super().write(self._eval_date(vals))
+                res_individual |= super(AccountAnalyticLine, record).write(vals)
+        return (
+            super(AccountAnalyticLine, self - self_individual).write(
+                self._eval_date(vals)
+            )
+            and res_individual
+        )
 
     def button_resume_work(self):
         """Create a new record starting now, with a running timer."""
         return {
-            "name": _("Resume work"),
+            "name": self.env._("Resume work"),
             "res_model": "hr.timesheet.switch",
             "target": "new",
             "type": "ir.actions.act_window",
@@ -153,11 +158,11 @@ class AccountAnalyticLine(models.Model):
         for line in self:
             if line.unit_amount:
                 raise UserError(
-                    _(
+                    self.env._(
                         "Cannot stop timer %d because it is not running. "
-                        "Refresh the page and check again."
+                        "Refresh the page and check again.",
+                        line.id,
                     )
-                    % line.id
                 )
             line.unit_amount = line._duration(line.date_time, end)
         return True

--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -92,6 +92,15 @@ class AccountAnalyticLine(models.Model):
             else:
                 one.show_time_control = "stop"
 
+    @api.onchange("date_time", "date_time_end")
+    def _onchange_date_time(self):
+        hour_uom = self.env.ref("uom.product_uom_hour")
+        if self.product_uom_id == hour_uom:
+            if self.date_time and self.date_time_end:
+                self.unit_amount = self._duration(self.date_time, self.date_time_end)
+            else:
+                self.unit_amount = 0
+
     @api.model_create_multi
     def create(self, vals_list):
         return super().create(list(map(self._eval_date, vals_list)))

--- a/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -94,6 +94,18 @@ class TestProjectTimesheetTimeControl(TestProjectTimesheetTimeControlBase):
         line.with_context(tz="EST").date_time = "2016-03-24 03:00:00"
         self.assertEqual(line.date, date(2016, 3, 23))
 
+    def test_write_analytic_line_date(self):
+        line = self._create_analytic_line(datetime(2016, 3, 24, 12, 0))
+        line2 = self._create_analytic_line(datetime(2016, 3, 23, 13, 0))
+
+        lines = self.env["account.analytic.line"]
+        lines += line
+        lines += line2
+
+        lines.write({"date": datetime(2016, 1, 1)})
+        self.assertEqual(line.date_time, datetime(2016, 1, 1, 12, 0))
+        self.assertEqual(line2.date_time, datetime(2016, 1, 1, 13, 0))
+
     def test_write_analytic_line_with_string_datetime(self):
         line = self._create_analytic_line(datetime.now())
         line.with_context(tz="EST").date_time = datetime(2016, 3, 24, 3)

--- a/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -290,3 +290,31 @@ class TestProjectTimesheetTimeControl(TestProjectTimesheetTimeControlBase):
         )
         line.unit_amount = 500.0
         self.assertFalse(line.date_time_end)
+
+    def test_onchange_date_time_with_hour_uom_and_dates(self):
+        hour_uom = self.env.ref("uom.product_uom_hour")
+        form = Form(
+            self.env["account.analytic.line"]
+            .with_user(self.user)
+            .with_context(default_product_uom_id=hour_uom.id),
+            view=self.env.ref("project_timesheet_time_control.hr_timesheet_line_form"),
+        )
+        form.date_time = datetime(2023, 1, 1, 8, 0, 0)
+        form.date_time_end = datetime(2023, 1, 1, 10, 0, 0)
+        self.assertEqual(form.unit_amount, 2.0)
+
+        form.date_time_end = datetime(2023, 1, 1, 12, 0, 0)
+        self.assertEqual(form.unit_amount, 4.0)
+
+    def test_onchange_date_time_with_hour_uom_no_end_date(self):
+        hour_uom = self.env.ref("uom.product_uom_hour")
+        form = Form(
+            self.env["account.analytic.line"]
+            .with_user(self.user)
+            .with_context(default_product_uom_id=hour_uom.id),
+            view=self.env.ref("project_timesheet_time_control.hr_timesheet_line_form"),
+        )
+        form.date_time = datetime(2023, 1, 1, 8, 0, 0)
+        form.date_time_end = False
+
+        self.assertEqual(form.unit_amount, 0)


### PR DESCRIPTION
1) In the Form view, the unit_amount field is only updated when saving the form, not when updating the date_time_end field.

<img width="1125" height="321" alt="image" src="https://github.com/user-attachments/assets/9cb99e34-4b33-4570-94c3-ffb1686dbb4d" />

2) The second commit synchronise the date field with the date_time. Before it was possible that date and date_time field had different date values when data was written to the date field. (Can be tested by makin the date field visible in the form and change/change+save the date field)

<img width="1122" height="341" alt="image" src="https://github.com/user-attachments/assets/05150e42-70f3-4b96-9510-ec644f8da7b8" />

3) Could you also have a look at this module, whether this should be displayed in a different module or could be added to this module? https://github.com/OCA/timesheet/pull/833

