### PR TITLE
[16.0][IMP] project_tag*: Remove auto_install=True

### DIFF
--- a/project_tag_hierarchy/__manifest__.py
+++ b/project_tag_hierarchy/__manifest__.py
@@ -9,7 +9,6 @@
     "license": "AGPL-3",
     "depends": ["project"],
     "installable": True,
-    "auto_install": True,
     "data": [
         "views/project_tags_views.xml",
     ],

--- a/project_tag_multicompany/__manifest__.py
+++ b/project_tag_multicompany/__manifest__.py
@@ -9,7 +9,6 @@
     "license": "AGPL-3",
     "depends": ["project"],
     "installable": True,
-    "auto_install": True,
     "data": [
         "security/project_tags_security.xml",
         "views/project_tags_views.xml",

--- a/project_tag_multicompany/static/description/index.html
+++ b/project_tag_multicompany/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -409,7 +410,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/project_tag_security/__manifest__.py
+++ b/project_tag_security/__manifest__.py
@@ -9,7 +9,6 @@
     "license": "AGPL-3",
     "depends": ["project"],
     "installable": True,
-    "auto_install": True,
     "data": [
         "views/project_project_views.xml",
         "views/project_tags_views.xml",


### PR DESCRIPTION
Backport from 18.0: https://github.com/OCA/project/pull/1584#issuecomment-3427356807

Remove auto_install=True to `project_tag_hierarchy`, `project_tag_multicompany` and `project_tag_security`.

Related to https://github.com/OCA/project/pull/1449#issuecomment-3411217883

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa