### PR TITLE
[16.0][IMP] project_stock: Add the option to cancel moves in a task

### DIFF
--- a/project_stock/README.rst
+++ b/project_stock/README.rst
@@ -71,6 +71,12 @@ Usage
     * `Cancel Materials`: Set the moves of the products as cancelled.
     * `Scrap`: Allows the defined products to be scrapped.
 
+Known issues / Roadmap
+======================
+
+#. Lot compatibility (similar to what happens in pickings).
+#. Release stock reserves if the task is deleted.
+
 Bug Tracker
 ===========
 

--- a/project_stock/models/account_analytic_line.py
+++ b/project_stock/models/account_analytic_line.py
@@ -9,6 +9,9 @@ class AccountAnalyticLine(models.Model):
     stock_task_id = fields.Many2one(
         comodel_name="project.task", string="Project Task", ondelete="cascade"
     )
+    stock_move_id = fields.Many2one(
+        comodel_name="stock.move", string="Stock Move", ondelete="cascade", copy=False
+    )
 
     def _timesheet_postprocess_values(self, values):
         """When hr_timesheet addon is installed, in the create() and write() methods,

--- a/project_stock/models/project_task.py
+++ b/project_stock/models/project_task.py
@@ -203,8 +203,11 @@ class ProjectTask(models.Model):
         """Cancel the stock moves and remove the analytic lines created from
         stock moves when cancelling the task.
         """
-        self.mapped("move_ids.move_line_ids").write({"qty_done": 0})
+        for move in self.move_ids:
+            move.action_cancel_from_task()
         # Use sudo to avoid error for users with no access to analytic
+        # Although the action_cancel_from_task() method should have deleted
+        # all analytical entries, we want to make sure there are no old records left.
         self.sudo().stock_analytic_line_ids.unlink()
         self.stock_moves_is_locked = True
         return True

--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -1,6 +1,7 @@
 # Copyright 2022-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 from odoo import api, fields, models
+from odoo.tools import float_is_zero
 
 
 class StockMove(models.Model):
@@ -14,6 +15,14 @@ class StockMove(models.Model):
     raw_material_task_id = fields.Many2one(
         comodel_name="project.task", string="Task for material", check_company=True
     )
+    analytic_line_ids = fields.One2many(
+        comodel_name="account.analytic.line",
+        inverse_name="stock_move_id",
+        string="Analytic Lines",
+    )
+    show_cancel_button_in_task = fields.Boolean(
+        compute="_compute_show_cancel_button_in_task"
+    )
 
     @api.onchange("product_id")
     def _onchange_product_id(self):
@@ -23,6 +32,57 @@ class StockMove(models.Model):
         if self.raw_material_task_id:
             self.name = self.raw_material_task_id.name
         return res
+
+    def _compute_show_cancel_button_in_task(self):
+        dp = self.env["decimal.precision"].precision_get("Product Unit of Measure")
+        for item in self:
+            item.show_cancel_button_in_task = bool(
+                item.raw_material_task_id
+                and item.raw_material_task_id.stock_moves_is_locked
+                and item.raw_material_task_id.done_stock_moves
+                and item.state not in ("draft", "cancel")
+                and (
+                    (
+                        item.state == "done"
+                        and not float_is_zero(item.quantity_done, precision_digits=dp)
+                    )
+                    or (
+                        item.state != "done"
+                        and not float_is_zero(item.product_uom_qty, precision_digits=dp)
+                    )
+                )
+            )
+
+    def action_cancel_from_task(self):
+        self.ensure_one()
+        if not self.show_cancel_button_in_task:
+            return
+        # Use sudo to avoid error for users with no access to analytic
+        analytic_lines = self.sudo().analytic_line_ids
+        task_analytic_lines = self.raw_material_task_id.sudo().stock_analytic_line_ids
+        if analytic_lines:
+            analytic_lines.unlink()
+        elif not analytic_lines and task_analytic_lines and self.state == "done":
+            # Previously, analytic lines were not linked to the stock_move_id field,
+            # so we have to deduce which ones were linked.
+            data = self._prepare_analytic_line_from_task()
+            if data:
+                # Depending on whether the account module is installed or not, it will
+                # be filtered by one field or another.
+                f_name = "product_id" if "product_id" in data else "name"
+                f_value = data[f_name]
+                analytic_lines = task_analytic_lines.filtered(
+                    lambda x: x.unit_amount == data["unit_amount"]
+                    and x[f_name] == f_value
+                )
+                analytic_lines.unlink()
+        # It is important to do this process at the end, so that if
+        # the _prepare_analytic_line_from_task() method is used, it has the correct
+        # value.
+        if self.state == "done":
+            self.move_line_ids.write({"qty_done": 0})
+        else:
+            self._action_cancel()
 
     def _prepare_analytic_line_from_task(self):
         product = self.product_id
@@ -49,6 +109,7 @@ class StockMove(models.Model):
             "product_uom_id": self.product_uom.id,
             "company_id": analytic_account.company_id.id or self.env.company.id,
             "partner_id": task.partner_id.id or task.project_id.partner_id.id or False,
+            "stock_move_id": self.id,
             "stock_task_id": task.id,
         }
         amount_unit = product.with_context(uom=self.product_uom.id).price_compute(

--- a/project_stock/readme/ROADMAP.rst
+++ b/project_stock/readme/ROADMAP.rst
@@ -1,0 +1,2 @@
+#. Lot compatibility (similar to what happens in pickings).
+#. Release stock reserves if the task is deleted.

--- a/project_stock/static/description/index.html
+++ b/project_stock/static/description/index.html
@@ -376,11 +376,12 @@ ul.auto-toc {
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -446,8 +447,15 @@ ul.auto-toc {
 </li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
+<ol class="arabic simple">
+<li>Lot compatibility (similar to what happens in pickings).</li>
+<li>Release stock reserves if the task is deleted.</li>
+</ol>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/project/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -455,15 +463,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Víctor Martínez</li>
@@ -473,7 +481,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/project_stock/tests/test_project_stock.py
+++ b/project_stock/tests/test_project_stock.py
@@ -213,6 +213,9 @@ class TestProjectStock(TestProjectStockBase):
         self.assertEqual(self.move_product_a.quantity_done, 2)
         self.assertEqual(self.move_product_b.quantity_done, 1)
         self.assertTrue(self.task.sudo().stock_analytic_line_ids)
+        # We do this to test the previous behavior (when an analytic
+        # lines was not linked to a stock move).
+        self.move_product_a.analytic_line_ids.stock_move_id = False
         # action_cancel
         self.task.action_cancel()
         self.assertEqual(self.move_product_a.state, "done")

--- a/project_stock/views/stock_move_view.xml
+++ b/project_stock/views/stock_move_view.xml
@@ -69,6 +69,15 @@
                 />
                 <field name="quantity_done" string="Consumed" readonly="1" />
                 <field name="group_id" invisible="1" />
+                <field name="show_cancel_button_in_task" invisible="1" />
+                <button
+                    name="action_cancel_from_task"
+                    type="object"
+                    class="btn-secondary"
+                    string="Cancel"
+                    attrs="{'invisible': [('show_cancel_button_in_task', '=', False)]}"
+                    confirm="Are you sure you want to proceed?"
+                />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Add the option to cancel moves in a task

Similar process to the existing "Cancel materials" in the task (applies to all moves).

<img width="1179" height="569" alt="ejemplo" src="https://github.com/user-attachments/assets/3b522d58-da41-4ce6-af10-58489b698b9c" />

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT58839