### PR TITLE
[16.0][REF] project_task_pull_request: add PR tab in task form before extra info

### DIFF
--- a/project_task_pull_request/views/project_task_pull_request_view.xml
+++ b/project_task_pull_request/views/project_task_pull_request_view.xml
@@ -7,16 +7,21 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.view_task_form2" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//page[@name='extra_info']//field[@name='sequence']"
-                position="before"
-            >
-                <field name="pr_required_states" attrs="{'invisible':True}" />
-                <field
-                    name="pr_uri"
-                    widget="url"
-                    attrs="{'invisible':[('pr_required_states', '=', [])]}"
-                />
+            <xpath expr="//notebook/page[@name='extra_info']" position="before">
+                <page
+                    name="pr_tab"
+                    string="Pull Request"
+                    groups="project.group_project_user"
+                >
+                    <group>
+                        <field name="pr_required_states" attrs="{'invisible': True}" />
+                        <field
+                            name="pr_uri"
+                            widget="url"
+                            attrs="{'invisible': [('pr_required_states', '=', [])]}"
+                        />
+                    </group>
+                </page>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Previously, the Pull Request fields (pr_uri, pr_required_states) were located in the “Extra Info” tab, which has `groups="base.group_no_one".`
This makes the tab hidden for all users outside developer mode, forcing users to enable debug mode to access and fill these fields — leading to validation errors when moving tasks to PR-required stages.

A new “Pull Request” tab has now been added, visible to project users, allowing PR information to be filled without enabling debug mode.

cc @marcelsavegnago @kaynnan @WesleyOliveira98 