### PR TITLE
[16.0][IMP] project_task_code_portal: add code to sharing views and sharing URL.

### DIFF
--- a/project_task_code_portal/README.rst
+++ b/project_task_code_portal/README.rst
@@ -1,7 +1,3 @@
-.. image:: https://odoo-community.org/readme-banner-image
-   :target: https://odoo-community.org/get-involved?utm_source=readme
-   :alt: Odoo Community Association
-
 ========================
 Project Task Code Portal
 ========================
@@ -17,7 +13,7 @@ Project Task Code Portal
 .. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
     :target: https://odoo-community.org/page/development-status
     :alt: Beta
-.. |badge2| image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-OCA%2Fproject-lightgray.png?logo=github
@@ -37,6 +33,8 @@ This module implements task codes in the portal. It allows users to:
 - Use task codes instead of IDs in portal URLs.
 - Search for tasks by their unique code.
 - Display task codes in portal task views.
+- Display in the task the URL to access to the task from the portal for
+  easy sharing.
 
 **Table of contents**
 

--- a/project_task_code_portal/__manifest__.py
+++ b/project_task_code_portal/__manifest__.py
@@ -14,5 +14,7 @@
     ],
     "data": [
         "templates/portal_templates.xml",
+        "views/project_sharing_views.xml",
+        "views/project_views.xml",
     ],
 }

--- a/project_task_code_portal/models/project_task.py
+++ b/project_task_code_portal/models/project_task.py
@@ -1,12 +1,34 @@
 # Copyright (C) 2025 Cetmix OÜ
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import fields, models
 
 
 class ProjectTask(models.Model):
     _inherit = "project.task"
 
+    portal_url = fields.Char(compute="_compute_portal_url")
+    portal_url_visible = fields.Boolean(compute="_compute_portal_url")
+
     @property
     def SELF_READABLE_FIELDS(self):
-        return super().SELF_READABLE_FIELDS | {"code"}
+        return super().SELF_READABLE_FIELDS | {
+            "code",
+            "portal_url",
+            "portal_url_visible",
+        }
+
+    @property
+    def SELF_WRITABLE_FIELDS(self):
+        return super().SELF_WRITABLE_FIELDS | {"code"}
+
+    def _compute_portal_url(self):
+        for rec in self:
+            rec.portal_url = ""
+            rec.portal_url_visible = False
+            if rec.project_id.privacy_visibility == "portal":
+                rec.portal_url_visible = True
+                base_url = rec.get_base_url()
+                rec.portal_url = (
+                    f"{base_url}/my/projects/{rec.project_id.id}/task/{rec.code}"
+                )

--- a/project_task_code_portal/readme/DESCRIPTION.md
+++ b/project_task_code_portal/readme/DESCRIPTION.md
@@ -3,3 +3,4 @@ This module implements task codes in the portal. It allows users to:
 - Use task codes instead of IDs in portal URLs.
 - Search for tasks by their unique code.
 - Display task codes in portal task views.
+- Display in the task the URL to access to the task from the portal for easy sharing.

--- a/project_task_code_portal/tests/test_portal.py
+++ b/project_task_code_portal/tests/test_portal.py
@@ -280,3 +280,23 @@ class TestPortalProjectTaskCode(TestProjectPortalCommon, HttpCaseWithUserPortal)
         url = f"{self.base_projects_url}/{other_project.id}/task/{task.code}"
         response = self.url_open(url)
         self.assertEqual(response.url, self.base_my_url)
+
+    def test_portal_url(self):
+        """Test that portal_url and portal_url_visible are correctly computed."""
+        other_project = self.env["project.project"].create(
+            {
+                "name": "Closed project",
+                "privacy_visibility": "portal",
+            }
+        )
+        task = self.env["project.task"].create(
+            {
+                "name": "Hidden task",
+                "project_id": other_project.id,
+                "code": "HIDDEN-CODE",
+            }
+        )
+        self.authenticate("portal", "portal")
+        url = f"{self.base_projects_url}/{other_project.id}/task/{task.code}"
+        self.assertEqual(task.portal_url_visible, True)
+        self.assertEqual(task.portal_url, url)

--- a/project_task_code_portal/views/project_sharing_views.xml
+++ b/project_task_code_portal/views/project_sharing_views.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="project_sharing_project_task_view_kanban" model="ir.ui.view">
+        <field name="name">project.sharing.project.task.view.kanban</field>
+        <field name="model">project.task</field>
+        <field
+            name="inherit_id"
+            ref="project.project_sharing_project_task_view_kanban"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='name']" position="before">
+                <span>[<field name="code" />] </span>
+            </xpath>
+            <xpath expr="//field[@name='name'][1]" position="before">
+                <span>[<field name="code" />] </span>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="project_sharing_project_task_view_tree" model="ir.ui.view">
+        <field name="name">project.sharing.project.task.tree</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.project_sharing_project_task_view_tree" />
+        <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field name="code" />
+            </field>
+        </field>
+    </record>
+
+    <record id="project_sharing_project_task_view_form" model="ir.ui.view">
+        <field name="name">project.sharing.project.task.view.form</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.project_sharing_project_task_view_form" />
+        <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field name="code" class="oe_inline" />
+                <span class="oe_inline"> - </span>
+            </field>
+            <field name="tag_ids" position="after">
+                <field name="portal_url_visible" invisible="1" />
+                <field
+                    name="portal_url"
+                    widget="CopyClipboardChar"
+                    options="{'string': 'Copy'}"
+                    attrs="{'invisible':[('portal_url_visible','=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="project_sharing_project_task_view_search" model="ir.ui.view">
+        <field name="name">project.task.search.form</field>
+        <field name="model">project.task</field>
+        <field
+            name="inherit_id"
+            ref="project.project_sharing_project_task_view_search"
+        />
+        <field name="arch" type="xml">
+            <field name="name" position="after">
+                <field name="code" string="Task Code" />
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/project_task_code_portal/views/project_views.xml
+++ b/project_task_code_portal/views/project_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="project_task_code_form_view" model="ir.ui.view">
+        <field name="name">project.task.code.form</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_form2" />
+        <field name="arch" type="xml">
+            <field name="allow_subtasks" position="after">
+                <field name="portal_url_visible" invisible="1" />
+            </field>
+            <field name="tag_ids" position="after">
+                <field
+                    name="portal_url"
+                    widget="CopyClipboardChar"
+                    options="{'string': 'Copy'}"
+                    attrs="{'invisible':[('portal_url_visible','=', False)]}"
+                />
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
The portal url is useful when you want to share the link with other project contributors. Otherwise an internal user will not know, when accessing the task from the backend, what would be the url to use when sharing the task with an external contributor

<img width="1403" height="662" alt="image" src="https://github.com/user-attachments/assets/00a0fc72-578c-49e5-9567-bb232a5fb0de" />

@halbtonjazz