### PR TITLE
[18.0][IMP] project_task_stock: Add the option to cancel moves in a task

### DIFF
--- a/project_task_stock/README.rst
+++ b/project_task_stock/README.rst
@@ -47,26 +47,26 @@ To configure this module, you need to:
 
 3. Create a new operation type with the following options:
 
-   - \`Operation type\`: Task material
-   - \`Code\`: TM
-   - \`Type of operation\`: Delivery
-   - \`Default Source Location\`: WH/Stock
-   - \`Default Destination Location\`: WH/Stock/Shelf 1
+   -  \`Operation type\`: Task material
+   -  \`Code\`: TM
+   -  \`Type of operation\`: Delivery
+   -  \`Default Source Location\`: WH/Stock
+   -  \`Default Destination Location\`: WH/Stock/Shelf 1
 
 4. Go to *Project -> Configuration -> Projects*.
 
 5. Create a new project with the following options:
 
-   - \`Name\`: Task material
-   - \`Operation type\`: Task material
+   -  \`Name\`: Task material
+   -  \`Operation type\`: Task material
 
 6. Go to *Project -> Configuration -> Task Stages* and edit some
    records.
 
-   - \`In progress\`: Check Use Stock Moves option and add the created
-     project.
-   - \`Done\`: Check Use Stock Moves option + Done Stock Moves and add
-     the created project.
+   -  \`In progress\`: Check Use Stock Moves option and add the created
+      project.
+   -  \`Done\`: Check Use Stock Moves option + Done Stock Moves and add
+      the created project.
 
 Usage
 =====
@@ -86,13 +86,19 @@ Usage
 
 6. *Stock Info* tab is readonly and some buttons show in header:
 
-   - \`Check availability materials\`: Product availability will be
-     checked.
-   - \`Transfer Materials\`: Stock moves are confirmed and moved from
-     one location to another.
-   - \`Unreserve\`: Remove the reservation stock of the products.
-   - \`Cancel Materials\`: Set the moves of the products as cancelled.
-   - \`Scrap\`: Allows the defined products to be scrapped.
+   -  \`Check availability materials\`: Product availability will be
+      checked.
+   -  \`Transfer Materials\`: Stock moves are confirmed and moved from
+      one location to another.
+   -  \`Unreserve\`: Remove the reservation stock of the products.
+   -  \`Cancel Materials\`: Set the moves of the products as cancelled.
+   -  \`Scrap\`: Allows the defined products to be scrapped.
+
+Known issues / Roadmap
+======================
+
+#. Lot compatibility (similar to what happens in pickings). #. Release
+stock reserves if the task is deleted.
 
 Bug Tracker
 ===========
@@ -115,10 +121,10 @@ Authors
 Contributors
 ------------
 
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Víctor Martínez
-  - Pedro M. Baeza
+   -  Víctor Martínez
+   -  Pedro M. Baeza
 
 Maintainers
 -----------

--- a/project_task_stock/models/account_analytic_line.py
+++ b/project_task_stock/models/account_analytic_line.py
@@ -9,6 +9,9 @@ class AccountAnalyticLine(models.Model):
     stock_task_id = fields.Many2one(
         comodel_name="project.task", string="Project Task", ondelete="cascade"
     )
+    stock_move_id = fields.Many2one(
+        comodel_name="stock.move", string="Stock Move", ondelete="cascade", copy=False
+    )
 
     def _timesheet_postprocess_values(self, values):
         """When hr_timesheet addon is installed, in the create() and write() methods,

--- a/project_task_stock/models/project_task.py
+++ b/project_task_stock/models/project_task.py
@@ -208,8 +208,11 @@ class ProjectTask(models.Model):
         """Cancel the stock moves and remove the analytic lines created from
         stock moves when cancelling the task.
         """
-        self.mapped("move_ids.move_line_ids").write({"quantity": 0})
+        for move in self.move_ids:
+            move.action_cancel_from_task()
         # Use sudo to avoid error for users with no access to analytic
+        # Although the action_cancel_from_task() method should have deleted
+        # all analytical entries, we want to make sure there are no old records left.
         self.sudo().stock_analytic_line_ids.unlink()
         self.stock_moves_is_locked = True
         return True

--- a/project_task_stock/readme/ROADMAP.md
+++ b/project_task_stock/readme/ROADMAP.md
@@ -1,0 +1,2 @@
+#. Lot compatibility (similar to what happens in pickings).
+#. Release stock reserves if the task is deleted.

--- a/project_task_stock/static/description/index.html
+++ b/project_task_stock/static/description/index.html
@@ -376,11 +376,12 @@ ul.auto-toc {
 <ul class="simple">
 <li><a class="reference internal" href="#configuration" id="toc-entry-1">Configuration</a></li>
 <li><a class="reference internal" href="#usage" id="toc-entry-2">Usage</a></li>
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
-<li><a class="reference internal" href="#contributors" id="toc-entry-6">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-7">Maintainers</a></li>
+<li><a class="reference internal" href="#known-issues-roadmap" id="toc-entry-3">Known issues / Roadmap</a></li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-4">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
+<li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -439,8 +440,13 @@ one location to another.</li>
 </li>
 </ol>
 </div>
+<div class="section" id="known-issues-roadmap">
+<h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
+<p>#. Lot compatibility (similar to what happens in pickings). #. Release
+stock reserves if the task is deleted.</p>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/project/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
@@ -448,15 +454,15 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-5">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
 <li>Tecnativa</li>
 </ul>
 </div>
 <div class="section" id="contributors">
-<h2><a class="toc-backref" href="#toc-entry-6">Contributors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-7">Contributors</a></h2>
 <ul class="simple">
 <li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
 <li>Víctor Martínez</li>
@@ -466,7 +472,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />

--- a/project_task_stock/tests/test_project_task_stock.py
+++ b/project_task_stock/tests/test_project_task_stock.py
@@ -211,6 +211,9 @@ class TestProjectTaskStock(TestProjectStockBase):
         self.assertEqual(self.move_product_a.quantity, 2)
         self.assertEqual(self.move_product_b.quantity, 1)
         self.assertTrue(self.task.sudo().stock_analytic_line_ids)
+        # We do this to test the previous behavior (when an analytic
+        # lines was not linked to a stock move).
+        self.move_product_a.analytic_line_ids.stock_move_id = False
         # action_cancel
         self.task.action_cancel()
         self.assertEqual(self.move_product_a.state, "done")

--- a/project_task_stock/views/stock_move_view.xml
+++ b/project_task_stock/views/stock_move_view.xml
@@ -59,6 +59,15 @@
                 <field name="product_uom_category_id" column_invisible="1" />
                 <field name="quantity" string="Consumed" readonly="1" />
                 <field name="group_id" column_invisible="1" />
+                <field name="show_cancel_button_in_task" column_invisible="1" />
+                <button
+                    name="action_cancel_from_task"
+                    type="object"
+                    class="btn-secondary"
+                    string="Cancel"
+                    invisible="not show_cancel_button_in_task"
+                    confirm="Are you sure you want to proceed?"
+                />
             </list>
         </field>
     </record>


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/project/pull/1592

Add the option to cancel moves in a task

Similar process to the existing "Cancel materials" in the task (applies to all moves).

<img width="1179" height="569" alt="ejemplo" src="https://github.com/user-attachments/assets/3b522d58-da41-4ce6-af10-58489b698b9c" />

Please @carlos-lopez-tecnativa and @pedrobaeza can you review it?

@Tecnativa TT58839