### PR TITLE
[16.0][FIX] project_stock: Perform proper value checks if account is installed

### DIFF
--- a/project_stock/models/stock_move.py
+++ b/project_stock/models/stock_move.py
@@ -71,6 +71,8 @@ class StockMove(models.Model):
                 # be filtered by one field or another.
                 f_name = "product_id" if "product_id" in data else "name"
                 f_value = data[f_name]
+                if f_name == "product_id":
+                    f_value = self.env["product.product"].browse(f_value)
                 analytic_lines = task_analytic_lines.filtered(
                     lambda x: x.unit_amount == data["unit_amount"]
                     and x[f_name] == f_value


### PR DESCRIPTION
Perform proper value checks if account is installed

`WARNING devel py.warnings: /opt/odoo/auto/addons/project_stock/models/stock_move.py:81: UserWarning: unsupported operand type(s) for "==": 'product.product()' == '43'`

Already added in https://github.com/OCA/project/pull/1607

Please @pedrobaeza can you review it?

@Tecnativa TT58839