### PR TITLE
[17.0] [IMP] project_parent: add constraint to prevent parent recursion

### DIFF
--- a/project_parent/models/project_project.py
+++ b/project_parent/models/project_project.py
@@ -1,7 +1,8 @@
 # Copyright 2019 Therp BV <https://therp.nl>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class Project(models.Model):
@@ -19,6 +20,11 @@ class Project(models.Model):
     parent_path = fields.Char(index="btree", unaccent=False)
 
     child_ids_count = fields.Integer(compute="_compute_child_ids_count", store=True)
+
+    @api.constrains("parent_id")
+    def _check_parent_id(self):
+        if not self._check_recursion():
+            raise ValidationError(_("You cannot create recursive projects."))
 
     @api.depends("child_ids")
     def _compute_child_ids_count(self):

--- a/project_parent/tests/test_project_parent.py
+++ b/project_parent/tests/test_project_parent.py
@@ -1,6 +1,7 @@
 # Copyright 2020 haulogy SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -26,3 +27,9 @@ class TestProjectParent(TransactionCase):
         self.assertEqual(
             res.get("context").get("default_parent_id"), self.project_project_1.id
         )
+
+    def test_project_recursion_check(self):
+        with self.assertRaisesRegex(
+            ValidationError, "Creating a cycle should raise ValidationError"
+        ):
+            self.project_project_1.parent_id = self.project_project_3.id


### PR DESCRIPTION
Adds a constraint to the project.project model to prevent creating recursive parent-child relationships (e.g., Project A → Project B → Project A).

Includes a corresponding test to verify the constraint blocks indirect recursion.

@BinhexTeam