### PR TITLE
[18.0][FIX] project_task_code_portal: Remove duplicated task code in kanban view

### DIFF
--- a/project_task_code_portal/views/project_sharing_views.xml
+++ b/project_task_code_portal/views/project_sharing_views.xml
@@ -11,9 +11,6 @@
             <xpath expr="//field[@name='name']" position="before">
                 <span>[<field name="code" />] </span>
             </xpath>
-            <xpath expr="//field[@name='name'][1]" position="before">
-                <span>[<field name="code" />] </span>
-            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Fixes this:
<img width="331" height="252" alt="image" src="https://github.com/user-attachments/assets/75aa1eb0-b20a-4a64-a176-e48dd8f92a00" />
