### PR TITLE
[FIX] project_task_pull_request: allow to put a pr_uri, without it is mandatory.

### DIFF
--- a/project_task_pull_request/views/project_task_pull_request_view.xml
+++ b/project_task_pull_request/views/project_task_pull_request_view.xml
@@ -12,7 +12,7 @@
                 position="before"
             >
                 <field name="pr_required_states" invisible="1" />
-                <field name="pr_uri" widget="url" invisible="not pr_required_states" />
+                <field name="pr_uri" widget="url" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Trivial

Rational: For the time being, a PR can be mandatory, if defined via pr_required_states settings. however, in some cases, user want to write this information, but not in all cases. So the field should not be hidden, even if it not required