### PR TITLE
Draft: [16.0][FIX] Project_task_code does not work with portal kanban sharing

### DIFF
--- a/project_task_code/models/project_task.py
+++ b/project_task_code/models/project_task.py
@@ -3,6 +3,10 @@
 
 from odoo import _, api, fields, models
 
+PROJECT_TASK_PORTAL_FIELDS = {
+    "code",
+}
+
 
 class ProjectTask(models.Model):
     _inherit = "project.task"
@@ -23,6 +27,14 @@ class ProjectTask(models.Model):
             _("The code must be unique!"),
         ),
     ]
+
+    @property
+    def SELF_READABLE_FIELDS(self):
+        return super().SELF_READABLE_FIELDS | PROJECT_TASK_PORTAL_FIELDS
+
+    @property
+    def SELF_WRITABLE_FIELDS(self):
+        return super().SELF_WRITABLE_FIELDS | PROJECT_TASK_PORTAL_FIELDS
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/project_task_code/tests/test_project_task_code.py
+++ b/project_task_code/tests/test_project_task_code.py
@@ -2,7 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import odoo.tests.common as common
-from odoo.exceptions import AccessError
 
 
 class TestProjectTaskCode(common.TransactionCase):
@@ -80,18 +79,23 @@ class TestProjectTaskCode(common.TransactionCase):
         self.assertIn("code", self.project_task_model.SELF_READABLE_FIELDS)
         self.assertIn("code", self.project_task_model.SELF_WRITABLE_FIELDS)
 
+    def test_portal_user_can_read_code_field(self):
+        portal_user = common.new_test_user(
+            self.env,
+            login="portal_project_task_code_read",
+            groups="base.group_portal",
+        )
+        fields = self.project_task_model.with_user(portal_user).SELF_READABLE_FIELDS
+        self.assertIn("code", fields)
+
     def test_portal_user_can_pass_code_self_write_check(self):
         portal_user = common.new_test_user(
             self.env,
-            login="portal_project_task_code",
+            login="portal_project_task_code_write",
             groups="base.group_portal",
         )
-
-        try:
-            self.project_task_model.with_user(portal_user)._ensure_fields_write(
-                {"name": "Portal Task", "code": "TASK-001"},
-                check_group_user=False,
-                defaults=True,
-            )
-        except AccessError as err:
-            self.fail("Portal self-write check should allow code field: %s" % err)
+        self.project_task_model.with_user(portal_user)._ensure_fields_write(
+            {"name": "Portal Task", "code": "TASK-001"},
+            check_group_user=False,
+            defaults=True,
+        )

--- a/project_task_code/tests/test_project_task_code.py
+++ b/project_task_code/tests/test_project_task_code.py
@@ -2,13 +2,13 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import odoo.tests.common as common
+from odoo.exceptions import AccessError
 
 
 class TestProjectTaskCode(common.TransactionCase):
     def setUp(self):
         super().setUp()
         self.project_task_model = self.env["project.task"]
-        self.ir_sequence_model = self.env["ir.sequence"]
         self.task_sequence = self.env.ref("project_task_code.sequence_task")
         self.project_task = self.env.ref("project.project_1_task_1")
 
@@ -45,29 +45,53 @@ class TestProjectTaskCode(common.TransactionCase):
         )
 
         result = project_task.name_search("TEST-123")
+        result_ids = [item[0] for item in result]
         self.assertIn(
             project_task.id,
-            map(lambda x: x[0], result),
-            f"Task with code {project_task.code} should be in the results",
+            result_ids,
+            "Task with code %s should be in the results" % project_task.code,
         )
 
         result = project_task.name_search("TEST")
+        result_ids = [item[0] for item in result]
         self.assertIn(
             project_task.id,
-            map(lambda x: x[0], result),
-            f"Task with code {project_task.code} should be in the results",
+            result_ids,
+            "Task with code %s should be in the results" % project_task.code,
         )
 
         result = project_task.name_search("much")
+        result_ids = [item[0] for item in result]
         self.assertIn(
             project_task.id,
-            map(lambda x: x[0], result),
-            f"Task with code {project_task.code} should be in the results",
+            result_ids,
+            "Task with code %s should be in the results" % project_task.code,
         )
 
         result = project_task.name_search("20232")
+        result_ids = [item[0] for item in result]
         self.assertNotIn(
             project_task.id,
-            map(lambda x: x[0], result),
-            f"Task with code {project_task.code} should not be in the results",
+            result_ids,
+            "Task with code %s should not be in the results" % project_task.code,
         )
+
+    def test_portal_self_fields_include_code(self):
+        self.assertIn("code", self.project_task_model.SELF_READABLE_FIELDS)
+        self.assertIn("code", self.project_task_model.SELF_WRITABLE_FIELDS)
+
+    def test_portal_user_can_pass_code_self_write_check(self):
+        portal_user = common.new_test_user(
+            self.env,
+            login="portal_project_task_code",
+            groups="base.group_portal",
+        )
+
+        try:
+            self.project_task_model.with_user(portal_user)._ensure_fields_write(
+                {"name": "Portal Task", "code": "TASK-001"},
+                check_group_user=False,
+                defaults=True,
+            )
+        except AccessError as err:
+            self.fail("Portal self-write check should allow code field: %s" % err)


### PR DESCRIPTION
This is a fix for portal_task_code  where you can invite a portaluser to be a 'sharing user' so that they can access an interactive project Kanban on portal however when a portal user creates a task via the project sharing view an AccessError is raised because the code field introduced by OCA/project_task_code is not included in SELF_WRITABLE_FIELDS.

To reproduce: 

- Enable project sharing on a project and invite a portal user to 'Share Editable'.
- then login as a portal user, open the shared project and create a new task.
- Task creation fails with: odoo.exceptions.AccessError: You cannot write on code fields in task.