### PR TITLE
[18.0][FIX] fix property view_type

### DIFF
--- a/project_parent/models/project_project.py
+++ b/project_parent/models/project_project.py
@@ -32,7 +32,6 @@ class Project(models.Model):
         domain = [("parent_id", "=", self.id)]
         return {
             "type": "ir.actions.act_window",
-            "view_type": "form",
             "name": f"Children of {self.name}",
             "view_mode": "list,form,graph",
             "res_model": "project.project",

--- a/project_template/models/project.py
+++ b/project_template/models/project.py
@@ -22,7 +22,6 @@ class Project(models.Model):
 
         # OPEN THE NEWLY CREATED PROJECT FORM
         return {
-            "view_type": "form",
             "view_mode": "form",
             "res_model": "project.project",
             "target": "current",

--- a/project_timesheet_time_control/models/account_analytic_line.py
+++ b/project_timesheet_time_control/models/account_analytic_line.py
@@ -160,7 +160,6 @@ class AccountAnalyticLine(models.Model):
             "target": "new",
             "type": "ir.actions.act_window",
             "view_mode": "form",
-            "view_type": "form",
         }
 
     def button_end_work(self):

--- a/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py
+++ b/project_timesheet_time_control/models/hr_timesheet_time_control_mixin.py
@@ -56,7 +56,6 @@ class HrTimesheetTimeControlMixin(models.AbstractModel):
             "target": "new",
             "type": "ir.actions.act_window",
             "view_mode": "form",
-            "view_type": "form",
         }
 
     def button_end_work(self):

--- a/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
+++ b/project_timesheet_time_control/tests/test_project_timesheet_time_control.py
@@ -62,7 +62,6 @@ class TestProjectTimesheetTimeControlBase(BaseCommon):
         self.assertEqual(action["target"], "new")
         self.assertEqual(action["type"], "ir.actions.act_window")
         self.assertEqual(action["view_mode"], "form")
-        self.assertEqual(action["view_type"], "form")
         wiz_form = Form(
             active_record.env[action["res_model"]].with_context(
                 active_id=active_record.id,

--- a/project_timesheet_time_control/wizards/hr_timesheet_switch.py
+++ b/project_timesheet_time_control/wizards/hr_timesheet_switch.py
@@ -202,6 +202,5 @@ class HrTimesheetSwitch(models.TransientModel):
                 "res_model": new._name,
                 "type": "ir.actions.act_window",
                 "view_mode": "form",
-                "view_type": "form",
                 "views": [(form_view.id, "form")],
             }


### PR DESCRIPTION
Avoid this warning:

`WARNING odoo odoo.addons.web.controllers.utils: Action 'Start work' contains custom properties 'view_type'. Passing them via the `params` or `context` properties is recommended instead  `