### PR TITLE
[14.0] [IMP] project_timeline: Move planning fields out of notebook page

### DIFF
--- a/project_timeline/views/project_task_view.xml
+++ b/project_timeline/views/project_task_view.xml
@@ -110,7 +110,7 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.view_task_form2" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='date_assign']" position="after">
+            <xpath expr="//field[@name='date_deadline']" position="before">
                 <label for="planned_date_start" string="Planned Dates" />
                 <div class="o_row">
                     <field


### PR DESCRIPTION
Backport from #1377