### PR TITLE
[18.0][FIX] project_task_default_stage: Do not set user_id on default stages

### DIFF
--- a/project_task_default_stage/__manifest__.py
+++ b/project_task_default_stage/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Project Task Default Stage",
     "summary": "Recovery default task stages for projects from v8",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Project",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/project",

--- a/project_task_default_stage/data/project_data.xml
+++ b/project_task_default_stage/data/project_data.xml
@@ -5,43 +5,51 @@
         <field name="sequence">10</field>
         <field name="name">Analysis</field>
         <field name="case_default" eval="True" />
+        <field name="user_id" eval="False" />
     </record>
     <record id="project_tt_specification" model="project.task.type">
         <field name="sequence">20</field>
         <field name="name">Specification</field>
         <field name="case_default" eval="True" />
+        <field name="user_id" eval="False" />
     </record>
     <record id="project_tt_design" model="project.task.type">
         <field name="sequence">30</field>
         <field name="name">Design</field>
         <field name="case_default" eval="True" />
+        <field name="user_id" eval="False" />
     </record>
     <record id="project_tt_development" model="project.task.type">
         <field name="sequence">40</field>
         <field name="name">Development</field>
         <field name="case_default" eval="True" />
+        <field name="user_id" eval="False" />
     </record>
     <record id="project_tt_testing" model="project.task.type">
         <field name="sequence">50</field>
         <field name="name">Testing</field>
         <field name="case_default" eval="True" />
+        <field name="user_id" eval="False" />
     </record>
     <record id="project_tt_merge" model="project.task.type">
         <field name="sequence">60</field>
         <field name="name">Merge</field>
         <field name="case_default" eval="False" />
         <field name="fold" eval="True" />
+        <field name="user_id" eval="False" />
     </record>
     <record id="project_tt_deployment" model="project.task.type">
         <field name="sequence">70</field>
         <field name="name">Done</field>
         <field name="case_default" eval="True" />
         <field name="fold" eval="True" />
+        <field name="user_id" eval="False" />
     </record>
     <record id="project_tt_cancel" model="project.task.type">
         <field name="sequence">80</field>
         <field name="name">Cancelled</field>
         <field name="case_default" eval="True" />
         <field name="fold" eval="True" />
+        <field name="user_id" eval="False" />
     </record>
 </odoo>

--- a/project_task_default_stage/migrations/18.0.1.0.1/post-migration.py
+++ b/project_task_default_stage/migrations/18.0.1.0.1/post-migration.py
@@ -1,0 +1,19 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    xml_ids = [
+        "project_task_default_stage.project_tt_analysis",
+        "project_task_default_stage.project_tt_specification",
+        "project_task_default_stage.project_tt_design",
+        "project_task_default_stage.project_tt_development",
+        "project_task_default_stage.project_tt_testing",
+        "project_task_default_stage.project_tt_merge",
+        "project_task_default_stage.project_tt_deployment",
+        "project_task_default_stage.project_tt_cancel",
+    ]
+    for xml_id in xml_ids:
+        task_type = env.ref(xml_id, raise_if_not_found=False)
+        if task_type:
+            task_type.user_id = False


### PR DESCRIPTION
Odoo has a global record rule that filters records based on user_id. Since this field has a default value of self.env.uid, these records become owned by the Odoo bot. If you try to access a record using self.env.ref("project_task_default_stage.project_tt_specification"), an error occurs.

https://github.com/odoo/odoo/blob/8a2eae27f46247a218facd3b8e27a67161934c8b/addons/project/security/project_security.xml#L122-L126

FWP of https://github.com/OCA/project/pull/1446

@pedrobaeza could you please review this