### PR TITLE
[18.0][FIX] project_task_pull_request: stage and project

### DIFF
--- a/project_task_pull_request/models/project_project.py
+++ b/project_task_pull_request/models/project_project.py
@@ -13,4 +13,5 @@ class ProjectProject(models.Model):
         "project_id",
         "state_id",
         "PR Required States",
+        domain="[('project_ids', 'in', [id])]",
     )


### PR DESCRIPTION
This PR fixes the domain filter for the pr_required_states field in the project.project model to display only task states (project.task.type) that belong to the current project, instead of showing all available states.