### PR TITLE
[16.0][FIX] project_task_project_required: do not delete project_id field default attrs in view_task_form2 view

### DIFF
--- a/project_task_project_required/views/project_task.xml
+++ b/project_task_project_required/views/project_task.xml
@@ -30,9 +30,10 @@
                 <field name="is_project_required" invisible="1" />
             </field>
             <field name="project_id" position="attributes">
+                <!-- The default odoo invisible attr is respected -->
                 <attribute
                     name="attrs"
-                >{'required':[('is_project_required','=',True)]}</attribute>
+                >{'invisible': [('parent_id', '!=', False)], 'required': [('is_project_required', '=', True)]}</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
This PR fixes a minor issue in this module.

The modified view overrides the [attributes of the following field](https://github.com/odoo/odoo/blob/16.0/addons/project/views/project_views.xml#L1167), removing the invisible attribute and **causing the field to be duplicated in some cases.**

This change still overrides the attributes, but now preserves the existing ones.

I also considered fixing this by using the add, remove, and separator attributes of the attribute tag to avoid overriding the attrs dictionary. However, matching dictionaries with that approach causes some issues.