### PR TITLE
[FIX] project_key - declare url/key kanban fields at root level

### DIFF
--- a/project_key/views/project_key_views.xml
+++ b/project_key/views/project_key_views.xml
@@ -85,10 +85,10 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.view_task_kanban" />
         <field name="arch" type="xml">
-            <field name="color" position="after">
+            <xpath expr="//field[@name='stage_id']" position="after">
                 <field name="url" />
                 <field name="key" />
-            </field>
+            </xpath>
             <xpath expr="//t[@t-name='card']//field[@name='name']" position="before">
                 <a t-att-href="record.url.raw_value">
                     <field name="key" />


### PR DESCRIPTION
In the kanban view, we have this currently : 
<img width="472" height="365" alt="image" src="https://github.com/user-attachments/assets/ef3fbd00-a932-4280-9c8b-84e657f36bc0" />

With the fix: 
<img width="474" height="363" alt="image" src="https://github.com/user-attachments/assets/3a6f626e-797b-41c4-bac6-944dd273e7ba" />
