### PR TITLE
[IMP] project_key - move project key in kanban view

### DIFF
--- a/project_key/views/project_key_views.xml
+++ b/project_key/views/project_key_views.xml
@@ -85,14 +85,11 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.view_task_kanban" />
         <field name="arch" type="xml">
-            <field name="color" position="after">
-                <field name="url" />
-                <field name="key" />
-            </field>
             <xpath expr="//t[@t-name='card']//field[@name='name']" position="before">
-                <a t-att-href="record.url.raw_value">
-                    <field name="key" />
-                </a>
+                <field name="key" invisible="1" />
+                <div t-if="record.key.raw_value" class="mb-1">
+                    <span class="badge text-bg-light" t-out="record.key.raw_value" />
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Currently the key is not properly shown in the kanban : 
<img width="472" height="365" alt="image" src="https://github.com/user-attachments/assets/5ba68149-a083-40ab-90b8-821da93086f6" />

With the improvement, I replaced the URL with a highlighted key in the kanban view.
(And it solves an issue for enterprise users who uses the Enterprise Gantt view)
<img width="456" height="252" alt="image" src="https://github.com/user-attachments/assets/fd2960af-2a86-4474-8811-f0a31d8cdc45" />