### PR TITLE
[IMP] project_key - add task key for portal users

### DIFF
--- a/project_key/controllers/__init__.py
+++ b/project_key/controllers/__init__.py
@@ -1,3 +1,4 @@
 # License LGPLv3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
 
 from . import main
+from . import portal

--- a/project_key/controllers/portal.py
+++ b/project_key/controllers/portal.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Noviat
+# License LGPLv3.0 or later (https://www.gnu.org/licenses/lgpl-3.0.en.html).
+
+from odoo.http import request
+
+from odoo.addons.project.controllers.portal import ProjectCustomerPortal
+
+
+class ProjectKeyCustomerPortal(ProjectCustomerPortal):
+    def _task_get_searchbar_inputs(self, milestones_allowed, project=False):
+        values = super()._task_get_searchbar_inputs(milestones_allowed, project)
+        values["key"] = {
+            "input": "key",
+            "label": request.env._("Search in Key"),
+            "sequence": 15,
+        }
+        return values
+
+    def _task_get_search_domain(self, search_in, search, milestones_allowed, project):
+        if search_in == "key":
+            return [("key", "ilike", search)]
+        return super()._task_get_search_domain(
+            search_in, search, milestones_allowed, project
+        )

--- a/project_key/models/project_task.py
+++ b/project_key/models/project_task.py
@@ -14,6 +14,14 @@ class Task(models.Model):
 
     url = fields.Char(string="URL", compute="_compute_task_url")
 
+    @property
+    def TASK_PORTAL_READABLE_FIELDS(self):
+        # Expose `key` so it's readable in portal & project sharing views
+        # (otherwise the JS kanban arch parser crashes when reading
+        # record.fields.key.type because the field is filtered out by
+        # the server response spec).
+        return super().TASK_PORTAL_READABLE_FIELDS | {"key"}
+
     _task_key_unique = models.Constraint(
         "UNIQUE(key)",
         "Task key must be unique!",

--- a/project_key/views/project_key_views.xml
+++ b/project_key/views/project_key_views.xml
@@ -60,7 +60,7 @@
     <record id="view_task_tree2_extend_with_key" model="ir.ui.view">
         <field name="name">project.task.list</field>
         <field name="model">project.task</field>
-        <field name="inherit_id" ref="project.view_task_tree2" />
+        <field name="inherit_id" ref="project.project_task_view_tree_main_base" />
         <field eval="2" name="priority" />
         <field name="arch" type="xml">
             <field name="name" position="before">
@@ -71,7 +71,7 @@
     <record id="view_task_search_key" model="ir.ui.view">
         <field name="name">project.task.search.key</field>
         <field name="model">project.task</field>
-        <field name="inherit_id" ref="project.view_task_search_form" />
+        <field name="inherit_id" ref="project.view_task_search_form_base" />
         <field name="arch" type="xml">
             <field name="name" position="attributes">
                 <attribute
@@ -106,4 +106,59 @@
             </div>
         </field>
     </record>
+    <record id="view_task_kanban_key_project_sharing" model="ir.ui.view">
+        <field name="name">project.sharing.project.task.kanban.key</field>
+        <field name="model">project.task</field>
+        <field
+            name="inherit_id"
+            ref="project.project_sharing_project_task_view_kanban"
+        />
+        <field name="active" eval="True" />
+        <field name="arch" type="xml">
+            <xpath expr="//t[@t-name='card']//field[@name='name']" position="before">
+                <field name="key" invisible="1" />
+                <div t-if="record.key.raw_value" class="mb-1">
+                    <span class="badge text-bg-light" t-out="record.key.raw_value" />
+                </div>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_task_form_key_project_sharing" model="ir.ui.view">
+        <field name="name">project.sharing.project.task.form.key</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.project_sharing_project_task_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//h1//field[@name='name']" position="before">
+                <field name="key" readonly="1" nolabel="1" class="oe_inline" />
+                <span class="oe_inline"> : </span>
+            </xpath>
+        </field>
+    </record>
+    <template
+        id="portal_tasks_list_key"
+        name="Project Key: portal tasks list"
+        inherit_id="project.portal_tasks_list"
+    >
+        <xpath expr="//tr/td[span[@t-esc='task.id']]" position="attributes">
+            <attribute name="t-if">not task.key</attribute>
+        </xpath>
+        <xpath expr="//tr/td[span[@t-esc='task.id']]" position="after">
+            <td t-if="task.key" class="text-start">
+                <span t-esc="task.key" />
+            </td>
+        </xpath>
+    </template>
+    <template
+        id="portal_my_task_key"
+        name="Project Key: portal task page"
+        inherit_id="project.portal_my_task"
+    >
+        <xpath expr="//h3/span[@t-field='task.name']" position="before">
+            <span
+                t-if="task.key"
+                class="badge text-bg-secondary me-2"
+                t-esc="task.key"
+            />
+        </xpath>
+    </template>
 </odoo>

--- a/project_key/views/project_key_views.xml
+++ b/project_key/views/project_key_views.xml
@@ -85,14 +85,13 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.view_task_kanban" />
         <field name="arch" type="xml">
-            <field name="color" position="after">
-                <field name="url" />
+            <xpath expr="//kanban/field[@name='stage_id']" position="after">
                 <field name="key" />
-            </field>
+            </xpath>
             <xpath expr="//t[@t-name='card']//field[@name='name']" position="before">
-                <a t-att-href="record.url.raw_value">
-                    <field name="key" />
-                </a>
+                <div t-if="record.key" class="mb-1">
+                    <span class="badge text-bg-light" t-out="record.key.raw_value" />
+                </div>
             </xpath>
         </field>
     </record>
@@ -115,9 +114,11 @@
         />
         <field name="active" eval="True" />
         <field name="arch" type="xml">
+            <xpath expr="//kanban/field[@name='state']" position="after">
+                <field name="key" />
+            </xpath>
             <xpath expr="//t[@t-name='card']//field[@name='name']" position="before">
-                <field name="key" invisible="1" />
-                <div t-if="record.key.raw_value" class="mb-1">
+                <div t-if="record.key" class="mb-1">
                     <span class="badge text-bg-light" t-out="record.key.raw_value" />
                 </div>
             </xpath>


### PR DESCRIPTION
I have added the task key in all the views related to the portal (read or edit)

For the edit part : 
<img width="1207" height="405" alt="image" src="https://github.com/user-attachments/assets/2dcfc1b3-21bd-458a-9ee3-c4d5a0705bc5" />
<img width="1286" height="413" alt="image" src="https://github.com/user-attachments/assets/2ee3cab9-3bea-4e1c-b046-7e0743697d56" />
<img width="827" height="686" alt="image" src="https://github.com/user-attachments/assets/5ab69e08-1397-4474-8f4c-35547aee5690" />

For the read part :
<img width="1423" height="358" alt="image" src="https://github.com/user-attachments/assets/4eb0bdeb-7e81-4ef3-8bb9-a47869a08668" />
<img width="1425" height="502" alt="image" src="https://github.com/user-attachments/assets/9857a98b-0910-434d-bbff-cc2d96b53e81" />
<img width="722" height="378" alt="image" src="https://github.com/user-attachments/assets/70800a1a-8bb5-48f9-9850-7f07b98a4878" />

Currently the key is not properly shown in the kanban : 
<img width="472" height="365" alt="image" src="https://github.com/user-attachments/assets/5ba68149-a083-40ab-90b8-821da93086f6" />

And with the improvement in the kanban view, I solve an issue when the kanban view is opened from the portal: 
```
project.webclient.min.js:4131 OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    Error: An error occured in the owl lifecycle (see this Error's "cause" property)
        at handleError (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:765:101)
        at App.handleError (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:1424:29)
        at Fiber._render (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:790:19)
        at Fiber.render (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:788:6)
        at ComponentNode.initiateRender (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:859:47)

Caused by: TypeError: Cannot read properties of undefined (reading 'raw_value')
    at KanbanRecord.template (eval at compile (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:1379:421), <anonymous>:35:31)
    at App.callTemplate (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:1015:129)
    at KanbanRecord.template (eval at compile (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:1379:421), <anonymous>:32:10)
    at Fiber._render (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:789:96)
    at Fiber.render (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:788:6)
    at ComponentNode.initiateRender (http://oca-project-19-0-pr1729-0aaafc3e3b89.runboat.odoo-community.org/web/assets/c79a56e/project.webclient.min.js:859:47)
```

With the improvement, I replaced the URL with a highlighted key in the kanban view.
<img width="456" height="252" alt="image" src="https://github.com/user-attachments/assets/fd2960af-2a86-4474-8811-f0a31d8cdc45" />