### PR TITLE
[19.0][FIX] project_sequence: make creation test independent of sale_project

### DIFF
--- a/project_sequence/tests/test_project_sequence.py
+++ b/project_sequence/tests/test_project_sequence.py
@@ -41,10 +41,14 @@ class TestProjectSequence(TransactionCase):
     @users("manager")
     def test_sequence_after_creation(self):
         """Sequence is applied only after project creation."""
-        prj_f = Form(self.env["project.project"])
-        self.assertFalse(prj_f.name)
-        self.assertFalse(prj_f.sequence_code)
-        proj = prj_f.save()
+        # Use new() instead of Form() so the test does not trigger unrelated
+        # onchanges from other installed modules (e.g. sale_project's
+        # _onchange_sale_line_id, which reads a field restricted to the
+        # sales group and would fail for a project-only manager user).
+        draft = self.env["project.project"].new({})
+        self.assertFalse(draft.name)
+        self.assertFalse(draft.sequence_code)
+        proj = self.env["project.project"].create({})
         self.assertTrue(proj.sequence_code)
         self.assertEqual(proj.name, proj.sequence_code)
         self.assertEqual(proj.sequence_code, "23-00011")


### PR DESCRIPTION
test_sequence_after_creation used Form(project.project) on a fresh record. Form initialization runs every model onchange to compute defaults, including sale_project's _onchange_sale_line_id, which reads reinvoiced_sale_order_id — a field restricted by sales_team.group_sale_salesman. When sale_project is installed in the same database, the project-only manager test user has no sale rights and the onchange raises AccessError, even though the behaviour being tested has nothing to do with sales. Check #1691 for an example.

Replace the Form-based pre-save check with a non-persisted new() record, which exercises the same invariant ("no sequence_code before creation") without triggering unrelated onchanges. The post-save assertions still use create() and remain unchanged.