### PR TITLE
[19.0][FIX] project_task_description_template: HTML fields wrap text in <p>

### DIFF
--- a/project_task_description_template/tests/test_project_task.py
+++ b/project_task_description_template/tests/test_project_task.py
@@ -21,7 +21,7 @@ class TestDescriptionTemplate(BaseCommon):
         record._onchange_description_template_id()
         self.assertEqual(
             record.description,
-            Markup("<p>Existing Description</p><span>- Sample Description</span>"),
+            Markup("<p>Existing Description</p><p>- Sample Description</p>"),
             "Onchange method failed to append description correctly.",
         )
 
@@ -31,6 +31,6 @@ class TestDescriptionTemplate(BaseCommon):
         record._onchange_description_template_id()
         self.assertEqual(
             record.description,
-            Markup("<span>- Sample Description</span>"),
+            Markup("<p>- Sample Description</p>"),
             "Onchange method failed with empty initial description.",
         )


### PR DESCRIPTION
`TestDescriptionTemplate` fails on 19.0: the two assertions expect the template
text wrapped in `<span>`, but Odoo 19.0's `Html` field now wraps bare text in
`<p>`. So `_onchange_description_template_id` produces `<p>- Sample Description</p>`.

The module behaviour is correct — only the test's hard-coded expectations were
stale. This updates them to `<p>`, turning the module's tests green again on the
19.0 branch.
