### PR TITLE
[19.0][FIX] project_task_description_template: make tests robust to HTML field wrapping

### DIFF
--- a/project_task_description_template/tests/test_project_task.py
+++ b/project_task_description_template/tests/test_project_task.py
@@ -16,12 +16,13 @@ class TestDescriptionTemplate(BaseCommon):
         )
 
     def test_onchange_description_template_id(self):
-        record = self.model.new({"description": "<p>Existing Description</p>"})
+        existing = Markup("<p>Existing Description</p>")
+        record = self.model.new({"description": existing})
         record.description_template_id = self.description_template
         record._onchange_description_template_id()
         self.assertEqual(
             record.description,
-            Markup("<p>Existing Description</p><span>- Sample Description</span>"),
+            existing + self.description_template.description,
             "Onchange method failed to append description correctly.",
         )
 
@@ -31,6 +32,6 @@ class TestDescriptionTemplate(BaseCommon):
         record._onchange_description_template_id()
         self.assertEqual(
             record.description,
-            Markup("<span>- Sample Description</span>"),
+            self.description_template.description,
             "Onchange method failed with empty initial description.",
         )


### PR DESCRIPTION
`TestDescriptionTemplate` fails on 19.0, and the failure oscillates: the two
onchange assertions pin the exact HTML wrapper of the appended template text,
but that wrapper is not stable across Odoo nightlies.

## Root cause
The `Html` field runs core's `html_sanitize()` (`odoo/tools/mail.py`) on write.
For *tagless* input its `fromstring()` returns the element libxml2 auto-creates
when it wraps the loose text in a `<p>`, and otherwise falls back to tagging the
body `<span>`. Whether libxml2 auto-wraps tagless text drifts between
Odoo/lxml builds — the assertions were flipped `<p>`→`<span>` only days ago and
are failing again now that core emits `<p>`. The module input
(`" - Sample Description"`) never changed; only the sanitiser output moved.

## Fix
Compare the result against the template's **own stored Html value** rather than
a hard-coded string. Both sides pass through the same sanitiser, so they agree
regardless of which branch of that code runs — no more tag flip-flop. Module
behaviour is unchanged, and the only remaining literal (`<p>Existing
Description</p>`) is a block element, stable across both regimes.

Verified on a clean `odoo:19.0` (`--test-enable --without-demo=all`): both tests
pass (`0 failed, 0 error(s) of 2 tests`).
