### PR TITLE
[18.0][FIX] project_key: keep breadcrumb on key link

### DIFF
--- a/project_key/views/project_key_views.xml
+++ b/project_key/views/project_key_views.xml
@@ -90,7 +90,7 @@
                 <field name="key" />
             </field>
             <xpath expr="//t[@t-name='card']//field[@name='name']" position="before">
-                <a t-att-href="record.url.raw_value">
+                <a type="open">
                     <field name="key" />
                 </a>
             </xpath>


### PR DESCRIPTION
This PR aims to preserve breadcrumb on kanban tasks view when the user click on key link added by this module.

<img width="354" height="144" alt="image" src="https://github.com/user-attachments/assets/359dcdb1-3010-426e-8725-5dda198ce8cc" />
