### PR TITLE
[18.0][FIX] project_group: compatibility with sale_project

### DIFF
--- a/project_group/views/project_project.xml
+++ b/project_group/views/project_project.xml
@@ -6,7 +6,7 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='privacy_visibility']/.." position="inside">
+            <xpath expr="//page[@name='settings']//field[@name='privacy_visibility']/.." position="inside">
                 <field
                     name="group_ids"
                     invisible="privacy_visibility != 'followers'"


### PR DESCRIPTION
The official module **sale_project** injects the *privacy_visibility* field in the *button_box* of the form, causing the *group_ids* field injected by **project_group** to be injected there too.

This PR changes the Xpath of the view to make sure the field is inserted in the right spot.