### PR TITLE
[19.0][IMP] project_group - extend to 'Invited internal and portal users'

### DIFF
--- a/project_group/security/project_project.xml
+++ b/project_group/security/project_project.xml
@@ -6,7 +6,7 @@
         <field name="name">Project: employees: Groups</field>
         <field name="model_id" ref="project.model_project_project" />
         <field name="domain_force">[
-                                        ('privacy_visibility', '=', 'followers'),
+                                        ('privacy_visibility', 'in', ('followers', 'invited_users')),
                                         ('group_ids', 'in', user.all_group_ids.ids)
                                     ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]" />
@@ -17,7 +17,7 @@
         <field name="model_id" ref="project.model_project_task" />
         <field name="domain_force">[
                                         ('project_id', '!=', False),
-                                        ('project_id.privacy_visibility', '=', 'followers'),
+                                        ('project_id.privacy_visibility', 'in', ('followers', 'invited_users')),
                                         ('project_id.group_ids', 'in', user.all_group_ids.ids)
                                     ]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]" />

--- a/project_group/tests/test_project_visibility.py
+++ b/project_group/tests/test_project_visibility.py
@@ -106,3 +106,37 @@ class TestProjectVisibility(BaseCommon):
             "employees",
             "privacy_visibility should be 'employees' after update",
         )
+
+    def test_03_invited_users_group_access(self):
+        """Group members get access on 'invited_users' projects."""
+        invited_project = self.ProjectObj.create(
+            {
+                "name": "Invited Users Project",
+                "privacy_visibility": "invited_users",
+                "group_ids": [Command.set([self.group1.id])],
+            }
+        )
+        self.project_group_user.write({"group_ids": [Command.link(self.group2.id)]})
+        self.assertNotIn(
+            invited_project,
+            self.ProjectObj.with_user(self.project_group_user).search(
+                [("id", "=", invited_project.id)]
+            ),
+            "User outside the project groups should not see the project",
+        )
+
+        self.project_group_user.write(
+            {
+                "group_ids": [
+                    Command.unlink(self.group2.id),
+                    Command.link(self.group1.id),
+                ]
+            }
+        )
+        self.assertIn(
+            invited_project,
+            self.ProjectObj.with_user(self.project_group_user).search(
+                [("id", "=", invited_project.id)]
+            ),
+            "User in a project group should see the 'invited_users' project",
+        )

--- a/project_group/views/project_project.xml
+++ b/project_group/views/project_project.xml
@@ -9,7 +9,7 @@
             <xpath expr="//field[@name='privacy_visibility']/.." position="inside">
                 <field
                     name="group_ids"
-                    invisible="privacy_visibility != 'followers'"
+                    invisible="privacy_visibility not in ('followers', 'invited_users')"
                     widget="many2many_tags"
                 />
             </xpath>


### PR DESCRIPTION
In version 19.0, Odoo added a new visibility option on projects called "Invited internal and portal users".
I extend this module to be able to use it with this new option.