### PR TITLE
[19.0][FIX] project_group - compatibility with sale_project

### DIFF
--- a/project_group/views/project_project.xml
+++ b/project_group/views/project_project.xml
@@ -6,7 +6,10 @@
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='privacy_visibility']/.." position="inside">
+            <xpath
+                expr="//page[@name='settings']//field[@name='privacy_visibility']/.."
+                position="inside"
+            >
                 <field
                     name="group_ids"
                     invisible="privacy_visibility != 'followers'"


### PR DESCRIPTION
Forward port from https://github.com/OCA/project/pull/1742

Issue remains in 19.0 : https://github.com/odoo/odoo/blob/6a356cb0640ce20c71f20a8bd64ef99e76a82489/addons/sale_project/views/project_task_views.xml#L55
