### PR TITLE
[18.0][FIX] project_task_stock: allow grouping by task for analytic lines

### DIFF
--- a/project_task_stock/models/stock_move.py
+++ b/project_task_stock/models/stock_move.py
@@ -135,6 +135,8 @@ class StockMove(models.Model):
         # Prevent incoherence when hr_timesheet addon is installed.
         if "project_id" in analytic_line_fields:
             vals["project_id"] = False
+        if "task_id" in analytic_line_fields:
+            vals["task_id"] = task.id
         # distributions
         if task.stock_analytic_distribution:
             new_amount = 0


### PR DESCRIPTION
Fixes #1689. When analytic lines are created from a stock move linked to a task, they previously lacked the \	ask_id\ field, making it impossible to group them by task in the analytic items view. This commit sets \	ask_id\ if it exists in the model.