### PR TITLE
[18.0][FIX] project_task_stock: improve order of project.task o2m

### DIFF
--- a/project_task_stock/views/stock_move_view.xml
+++ b/project_task_stock/views/stock_move_view.xml
@@ -16,7 +16,6 @@
         <field name="arch" type="xml">
             <list
                 editable="bottom"
-                default_order="sequence"
                 decoration-muted="state in ('done', 'cancel')"
                 decoration-warning="quantity - product_uom_qty &gt; 0.0001"
                 decoration-success="state not in ('done', 'cancel') and quantity - product_uom_qty &lt; 0.0001"


### PR DESCRIPTION
cc @Tecnativa TT63680
ping @pedrobaeza 

The embedded list for `move_ids` uses `default_order="sequence"`, which the web
client forwards as the x2many order, replacing the comodel's `_order`
(`sequence, id`). All moves default to `sequence = 10`, so the lines are tied
and PostgreSQL returns them in arbitrary order.