### PR TITLE
[18.0][FIX] project_task_name_with_id: add active field 

### DIFF
--- a/project_task_name_with_id/views/project_task_views.xml
+++ b/project_task_name_with_id/views/project_task_views.xml
@@ -58,6 +58,7 @@
                 <attribute name="invisible">1</attribute>
             </xpath>
             <xpath expr="//field[@name='name']" position="after">
+                <field name="active" invisible="1" />
                 <span class="fw-bold fs-5">
                     <s t-if="!record.active.raw_value">
                         <field name="display_name" widget="name_with_subtask_count" />


### PR DESCRIPTION
The project sharing kanban view inherits the original project_sharing_project_task_view_kanban which does not include the `active` field in its arch. The inherited view references `record.active.raw_value` to toggle strikethrough on inactive tasks, but since `active` is not declared as a field in the view, the record value is undefined at render time, causing:

  `TypeError: Cannot read properties of undefined (reading 'raw_value')`

Add an invisible `active` field so the value is available in the kanban record data, allowing the t-if conditional to evaluate correctly.

How to reproduce this error with enterprise modules installed:
[Screencast from 2026-07-16 08-01-00.webm](https://github.com/user-attachments/assets/f2f414b1-f049-4ccf-940b-db307447c9ad)
