### PR TITLE
[19.0][IMP] project_task_code: per-project task name display

### DIFF
--- a/project_task_code/README.rst
+++ b/project_task_code/README.rst
@@ -42,6 +42,17 @@ This module adds a sequential code for tasks.
 Configuration
 =============
 
+To choose how the tasks of a project are identified, you must:
+
+1. Go to Project > Configuration > Projects and open a project.
+2. In the Settings tab, set "Task Name Display" to:
+
+   - "Number and Title" (default) to show the task number followed by
+     its title.
+   - "Number only" to show the task number alone. Titles are still
+     stored (so, for instance, tasks created from an incoming email keep
+     the mail subject) but they are neither displayed nor required.
+
 To change the task code sequence, you must:
 
 1. Activate the developer mode.
@@ -94,6 +105,7 @@ Contributors
 - Tharathip Chaweewongphan <tharathipc@ecosoft.co.th>
 - Ruchir Shukla <ruchir@bizzappdev.com>
 - Nedas Žilinskas <nedas.zilinskas@avoin.systems>
+- Jasmin Solanki <jasmin.solanki@forgeflow.com>
 
 Maintainers
 -----------

--- a/project_task_code/models/__init__.py
+++ b/project_task_code/models/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from . import project_project
 from . import project_task

--- a/project_task_code/models/project_project.py
+++ b/project_task_code/models/project_project.py
@@ -1,0 +1,21 @@
+# Copyright 2026 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProjectProject(models.Model):
+    _inherit = "project.project"
+
+    task_name_display = fields.Selection(
+        selection=[
+            ("code_name", "Number and Title"),
+            ("code", "Number only"),
+        ],
+        default="code_name",
+        required=True,
+        help="How the tasks of this project are identified:\n"
+        "- Number and Title: the task number followed by its title.\n"
+        "- Number only: the task number alone; titles are kept but not "
+        "displayed, and are not required.",
+    )

--- a/project_task_code/models/project_task.py
+++ b/project_task_code/models/project_task.py
@@ -15,6 +15,14 @@ class ProjectTask(models.Model):
         readonly=True,
         copy=False,
     )
+    # Tasks of a project displaying the number alone need no title, so the
+    # requirement is moved to the view, where it only applies to projects
+    # displaying the title.
+    name = fields.Char(required=False)
+    task_name_display = fields.Selection(
+        related="project_id.task_name_display",
+        readonly=True,
+    )
 
     _code_company_uniq = models.Constraint(
         "unique (company_id, code)",
@@ -30,10 +38,24 @@ class ProjectTask(models.Model):
                 )
         return super().create(vals_list)
 
-    @api.depends("name", "code")
+    def copy_data(self, default=None):
+        vals_list = super().copy_data(default=default)
+        for task, vals in zip(self, vals_list, strict=True):
+            # An untitled task must stay untitled, instead of getting the
+            # "False (copy)" title built by the standard copy.
+            if not task.name and not (default or {}).get("name"):
+                vals["name"] = False
+        return vals_list
+
+    @api.depends("name", "code", "task_name_display")
     def _compute_display_name(self):
         result = super()._compute_display_name()
         for task in self:
-            if task.code and task.code != "/" and task.display_name:
-                task.display_name = f"[{task.code}] {task.display_name}"
+            if not task.code or task.code == "/":
+                continue
+            name = task.display_name
+            if task.task_name_display == "code" or not name:
+                task.display_name = task.code
+            else:
+                task.display_name = f"[{task.code}] {name}"
         return result

--- a/project_task_code/readme/CONFIGURE.md
+++ b/project_task_code/readme/CONFIGURE.md
@@ -1,3 +1,13 @@
+To choose how the tasks of a project are identified, you must:
+
+1.  Go to Project \> Configuration \> Projects and open a project.
+2.  In the Settings tab, set "Task Name Display" to:
+    - "Number and Title" (default) to show the task number followed by
+      its title.
+    - "Number only" to show the task number alone. Titles are still
+      stored (so, for instance, tasks created from an incoming email keep
+      the mail subject) but they are neither displayed nor required.
+
 To change the task code sequence, you must:
 
 1.  Activate the developer mode.

--- a/project_task_code/readme/CONTRIBUTORS.md
+++ b/project_task_code/readme/CONTRIBUTORS.md
@@ -10,3 +10,4 @@
 - Tharathip Chaweewongphan \<<tharathipc@ecosoft.co.th>\>
 - Ruchir Shukla \<<ruchir@bizzappdev.com>\>
 - Nedas Žilinskas \<<nedas.zilinskas@avoin.systems>\>
+- Jasmin Solanki \<<jasmin.solanki@forgeflow.com>\>

--- a/project_task_code/static/description/index.html
+++ b/project_task_code/static/description/index.html
@@ -392,6 +392,18 @@ ul.auto-toc {
 </div>
 <div class="section" id="configuration">
 <h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
+<p>To choose how the tasks of a project are identified, you must:</p>
+<ol class="arabic simple">
+<li>Go to Project &gt; Configuration &gt; Projects and open a project.</li>
+<li>In the Settings tab, set “Task Name Display” to:<ul>
+<li>“Number and Title” (default) to show the task number followed by
+its title.</li>
+<li>“Number only” to show the task number alone. Titles are still
+stored (so, for instance, tasks created from an incoming email keep
+the mail subject) but they are neither displayed nor required.</li>
+</ul>
+</li>
+</ol>
 <p>To change the task code sequence, you must:</p>
 <ol class="arabic simple">
 <li>Activate the developer mode.</li>
@@ -441,6 +453,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Tharathip Chaweewongphan &lt;<a class="reference external" href="mailto:tharathipc&#64;ecosoft.co.th">tharathipc&#64;ecosoft.co.th</a>&gt;</li>
 <li>Ruchir Shukla &lt;<a class="reference external" href="mailto:ruchir&#64;bizzappdev.com">ruchir&#64;bizzappdev.com</a>&gt;</li>
 <li>Nedas Žilinskas &lt;<a class="reference external" href="mailto:nedas.zilinskas&#64;avoin.systems">nedas.zilinskas&#64;avoin.systems</a>&gt;</li>
+<li>Jasmin Solanki &lt;<a class="reference external" href="mailto:jasmin.solanki&#64;forgeflow.com">jasmin.solanki&#64;forgeflow.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/project_task_code/tests/test_project_task_code.py
+++ b/project_task_code/tests/test_project_task_code.py
@@ -65,6 +65,51 @@ class TestProjectTaskCode(BaseCommon):
             f"Task with code {project_task.code} should not be in the results",
         )
 
+    def test_display_name_code_only_project(self):
+        project = self.env["project.project"].create(
+            {"name": "Code only", "task_name_display": "code"}
+        )
+        task = self.project_task_model.create(
+            {"name": "Testing task code", "project_id": project.id}
+        )
+        self.assertEqual(task.display_name, task.code)
+
+    def test_task_without_name_on_code_only_project(self):
+        project = self.env["project.project"].create(
+            {"name": "Code only", "task_name_display": "code"}
+        )
+        task = self.project_task_model.create({"project_id": project.id})
+        self.assertFalse(task.name)
+        self.assertEqual(task.display_name, task.code)
+
+    def test_duplicated_task_without_name_stays_untitled(self):
+        project = self.env["project.project"].create(
+            {"name": "Code only", "task_name_display": "code"}
+        )
+        task = self.project_task_model.create({"project_id": project.id})
+        copied = task.copy()
+        self.assertNotEqual(copied.code, task.code)
+        self.assertFalse(copied.name)
+        self.assertEqual(copied.display_name, copied.code)
+
+    def test_duplicated_task_with_name_keeps_the_copy_suffix(self):
+        task = self.project_task_model.create({"name": "Testing task code"})
+        copied = task.copy()
+        self.assertIn("(copy)", copied.name)
+
+    def test_display_name_falls_back_to_code_without_name(self):
+        project = self.env["project.project"].create({"name": "With titles"})
+        self.assertEqual(project.task_name_display, "code_name")
+        task = self.project_task_model.create({"project_id": project.id})
+        self.assertEqual(task.display_name, task.code)
+
+    def test_display_name_code_and_name_project(self):
+        project = self.env["project.project"].create({"name": "With titles"})
+        task = self.project_task_model.create(
+            {"name": "Testing task code", "project_id": project.id}
+        )
+        self.assertEqual(task.display_name, f"[{task.code}] Testing task code")
+
     def test_name_get_on_create(self):
         number_next = self.task_sequence.number_next_actual
         code = self.task_sequence.get_next_char(number_next)

--- a/project_task_code/views/project_view.xml
+++ b/project_task_code/views/project_view.xml
@@ -1,13 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
+    <record id="project_project_task_name_display_form_view" model="ir.ui.view">
+        <field name="name">project.project.form.task.name.display</field>
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project" />
+        <field name="arch" type="xml">
+            <group name="extra_settings" position="inside">
+                <field name="task_name_display" widget="radio" />
+            </group>
+        </field>
+    </record>
     <record id="project_task_code_form_view" model="ir.ui.view">
         <field name="name">project.task.code.form</field>
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.view_task_form2" />
         <field name="arch" type="xml">
             <field name="name" position="before">
+                <field name="task_name_display" invisible="1" />
                 <field name="code" class="oe_inline" />
-                <span class="oe_inline"> - </span>
+                <span
+                    class="oe_inline"
+                    invisible="task_name_display == 'code'"
+                > - </span>
+            </field>
+            <!--
+                Projects displaying the number alone hide the title, so it
+                cannot be required there. The field itself is not required at
+                model level for that reason.
+            -->
+            <field name="name" position="attributes">
+                <attribute name="invisible">task_name_display == 'code'</attribute>
+                <attribute name="required">task_name_display != 'code'</attribute>
             </field>
         </field>
     </record>
@@ -35,6 +58,12 @@
             <!-- Move the name field inside the task_code div to ensure it appears after the code on a single line. -->
             <xpath expr="//div[@name='task_code']" position="inside">
                 <xpath expr="//field[@name='name']" position="move" />
+            </xpath>
+            <xpath
+                expr="//div[@name='task_code']/field[@name='name']"
+                position="attributes"
+            >
+                <attribute name="invisible">task_name_display == 'code'</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Adds a Task Name Display setting on the project, choosing how its tasks are identified:

 - Number and Title (default) — the current [code] Title behaviour, unchanged.
 - Number only — the task number alone. The title is hidden in the form and kanban and is no longer required, so tasks can be identified by their number without carrying a redundant title.

 This replaces the usual downstream workaround of overwriting name with code and flattening display_name, which destroys the title at the data level — most visibly for tasks created from an incoming email, where Odoo puts the mail subject in the title.

 Two related fixes come with it:

 - display_name falls back to the task number when a task has no title, instead of computing an empty display name.
 - Duplicating an untitled task keeps it untitled, instead of producing a "False (copy)" title.

 name is redefined as not required at model level (a number-only project has no title to require); the requirement moves to the form view, where it applies only to projects displaying the title.