### PR TITLE
[18.0][FIX] project_task_stock: Set picked = True for pending moves

### DIFF
--- a/project_task_stock/models/project_task.py
+++ b/project_task_stock/models/project_task.py
@@ -233,6 +233,10 @@ class ProjectTask(models.Model):
             lambda x: float_is_zero(x.quantity, precision_digits=price_dp)
         ):
             move.quantity = move.product_uom_qty
+        # It is important to set picked=True to avoid inconsistencies between
+        # picked=True and picked=False` operations that prevent the picking process
+        # from being completed.
+        moves_to_do.picked = True
         moves_to_do.picking_id.with_context(skip_sanity_check=True).button_validate()
 
     def action_see_move_scrap(self):

--- a/project_task_stock/tests/test_project_task_stock.py
+++ b/project_task_stock/tests/test_project_task_stock.py
@@ -69,6 +69,38 @@ class TestProjectTaskStock(TestProjectStockBase):
         if "project_id" in self.task.stock_analytic_line_ids._fields:
             self.assertFalse(self.task.stock_analytic_line_ids.project_id)
 
+    @mute_logger("odoo.models.unlink")
+    def test_project_task_picked_flow(self):
+        self.move_product_b.unlink()
+        self.task.action_assign()
+        self.assertEqual(self.move_product_a.state, "assigned")
+        self.assertFalse(self.move_product_a.picked)
+        self.move_product_a.product_uom_qty = 4
+        self.task.action_assign()
+        self.assertEqual(self.move_product_a.state, "partially_available")
+        self.assertFalse(self.move_product_a.picked)
+        self.task.action_done()
+        self.assertEqual(self.move_product_a.state, "partially_available")
+        self.assertTrue(self.move_product_a.picked)
+        # new line
+        task_form = Form(self.task)
+        with task_form.move_ids.new() as move_form:
+            move_form.product_id = self.product_b
+            move_form.product_uom_qty = 1
+        task_form.save()
+        move_product_b = self.task.move_ids - self.move_product_a
+        self.move_product_a.product_uom_qty = 2
+        self.task.action_assign()
+        self.assertEqual(self.move_product_a.state, "assigned")
+        self.assertTrue(self.move_product_a.picked)
+        self.assertEqual(move_product_b.state, "assigned")
+        self.assertFalse(move_product_b.picked)
+        self.task.action_done()
+        self.assertEqual(self.move_product_a.state, "done")
+        self.assertTrue(self.move_product_a.picked)
+        self.assertEqual(move_product_b.state, "done")
+        self.assertTrue(move_product_b.picked)
+
     def test_project_task_without_analytic_account(self):
         self.task = self.env["project.task"].browse(self.task.id)
         # Prevent error when hr_timesheet addon is installed.


### PR DESCRIPTION
Set picked = True for pending moves

You must set picked = True for pending moves to prevent the picking process from failing if there are moves with both picked = True and picked = False

Example use case:
- Add a line item for Product A, for which demand exceeds current stock
- Click the "Check Material Availability" button
- Click "Transfer Materials"
- Add more stock of Product A to meet demand
- Add a line item for Product B
- Click the "Check Material Availability" button
- Click "Transfer Materials"
- All line items will be completed

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT64069