### PR TITLE
[18.0][FIX] project_task_stock: Hide the Stock Info page if the record has not been created

### DIFF
--- a/project_task_stock/views/project_task_view.xml
+++ b/project_task_stock/views/project_task_view.xml
@@ -109,7 +109,7 @@
                 <page
                     name="stock_info"
                     string="Stock Info"
-                    invisible="not use_stock_moves"
+                    invisible="not use_stock_moves or not id"
                     groups="stock.group_stock_user"
                 >
                     <field name="done_stock_moves" invisible="1" />


### PR DESCRIPTION
Hide the Stock Info page if the record has not been created

Related to https://github.com/OCA/project/pull/1787#issuecomment-5239241374

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa 