### PR TITLE
[18.0][FIX] project_task_default_stage: migration script method signa…

### DIFF
--- a/project_task_default_stage/migrations/18.0.1.0.1/post-migration.py
+++ b/project_task_default_stage/migrations/18.0.1.0.1/post-migration.py
@@ -2,7 +2,7 @@ from openupgradelib import openupgrade
 
 
 @openupgrade.migrate()
-def migrate(env, version):
+def migrate(cr, version):
     xml_ids = [
         "project_task_default_stage.project_tt_analysis",
         "project_task_default_stage.project_tt_specification",
@@ -14,6 +14,6 @@ def migrate(env, version):
         "project_task_default_stage.project_tt_cancel",
     ]
     for xml_id in xml_ids:
-        task_type = env.ref(xml_id, raise_if_not_found=False)
+        task_type = cr.ref(xml_id, raise_if_not_found=False)
         if task_type:
             task_type.user_id = False


### PR DESCRIPTION
…ture

When trying to update I have the following error.
```
processed_modules += load_marked_modules(env, graph,
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/odoo/src/odoo/modules/loading.py", line 365, in load_marked_modules
      loaded, processed = load_module_graph(
                          ^^^^^^^^^^^^^^^^^^
    File "/odoo/src/odoo/modules/loading.py", line 233, in load_module_graph
      migrations.migrate_module(package, 'post')
    File "/odoo/src/odoo/modules/migration.py", line 217, in migrate_module
      exec_script(self.cr, installed_version, pyfile, pkg.name, stage, version)
    File "/odoo/src/odoo/modules/migration.py", line 255, in exec_script
      raise TypeError("module %(addon)s: `migrate`'s signature should be `(cr, version)`, %(func)s is %(sig)s" % dict(locals(), func=mod.migrate, sig=sig))
  TypeError: module project_task_default_stage: `migrate`'s signature should be `(cr, version)`, <function migrate at 0x7fbc8a8b7c40> is (env, version)
  2026-08-24 16:25:44,862 92 INFO prod odoo.service.server: Initiating shutdown
  2026-08-24 16:25:44,862 92 INFO prod odoo.service.server: Hit CTRL-C again or send a second signal to force the shutdown.
  2026-08-24 16:25:44,862 92 INFO prod odoo.sql_db: ConnectionPool(read/write;used=0/count=0/max=64): Closed 1 connections
```
